### PR TITLE
Added description field to nodes.

### DIFF
--- a/Forge.Tests/Statescript/ExpressionResolverTests.cs
+++ b/Forge.Tests/Statescript/ExpressionResolverTests.cs
@@ -34,7 +34,7 @@ public class ExpressionResolverTests(TagsAndCuesFixture tagsAndCuesFixture) : IC
 				ComparisonOperation.GreaterThan,
 				new VariantResolver(new Variant128(10.0), typeof(double))));
 
-		var condition = new ExpressionConditionNode("isAboveThreshold");
+		var condition = new ExpressionNode("isAboveThreshold");
 		var trueAction = new TrackingActionNode();
 		var falseAction = new TrackingActionNode();
 
@@ -71,7 +71,7 @@ public class ExpressionResolverTests(TagsAndCuesFixture tagsAndCuesFixture) : IC
 				ComparisonOperation.GreaterThan,
 				new VariantResolver(new Variant128(10.0), typeof(double))));
 
-		var condition = new ExpressionConditionNode("isAboveThreshold");
+		var condition = new ExpressionNode("isAboveThreshold");
 		var trueAction = new TrackingActionNode();
 		var falseAction = new TrackingActionNode();
 
@@ -108,7 +108,7 @@ public class ExpressionResolverTests(TagsAndCuesFixture tagsAndCuesFixture) : IC
 				ComparisonOperation.Equal,
 				new VariantResolver(new Variant128(42.0), typeof(double))));
 
-		var condition = new ExpressionConditionNode("isEqual");
+		var condition = new ExpressionNode("isEqual");
 		var trueAction = new TrackingActionNode();
 		var falseAction = new TrackingActionNode();
 
@@ -148,7 +148,7 @@ public class ExpressionResolverTests(TagsAndCuesFixture tagsAndCuesFixture) : IC
 				ComparisonOperation.GreaterThan,
 				new VariableResolver("threshold", typeof(double))));
 
-		var condition = new ExpressionConditionNode("isHealthAboveThreshold");
+		var condition = new ExpressionNode("isHealthAboveThreshold");
 		var trueAction = new TrackingActionNode();
 		var falseAction = new TrackingActionNode();
 
@@ -185,7 +185,7 @@ public class ExpressionResolverTests(TagsAndCuesFixture tagsAndCuesFixture) : IC
 				ComparisonOperation.LessThanOrEqual,
 				new VariantResolver(new Variant128(10.0), typeof(double))));
 
-		var condition = new ExpressionConditionNode("atBoundary");
+		var condition = new ExpressionNode("atBoundary");
 		var trueAction = new TrackingActionNode();
 		var falseAction = new TrackingActionNode();
 
@@ -222,7 +222,7 @@ public class ExpressionResolverTests(TagsAndCuesFixture tagsAndCuesFixture) : IC
 				ComparisonOperation.NotEqual,
 				new VariantResolver(new Variant128(2.0), typeof(double))));
 
-		var condition = new ExpressionConditionNode("isDifferent");
+		var condition = new ExpressionNode("isDifferent");
 		var trueAction = new TrackingActionNode();
 		var falseAction = new TrackingActionNode();
 
@@ -253,7 +253,7 @@ public class ExpressionResolverTests(TagsAndCuesFixture tagsAndCuesFixture) : IC
 	{
 		var graph = new Graph();
 
-		var condition = new ExpressionConditionNode("nonexistent");
+		var condition = new ExpressionNode("nonexistent");
 		var trueAction = new TrackingActionNode();
 		var falseAction = new TrackingActionNode();
 
@@ -293,7 +293,7 @@ public class ExpressionResolverTests(TagsAndCuesFixture tagsAndCuesFixture) : IC
 				ComparisonOperation.GreaterThanOrEqual,
 				new VariableResolver("requiredScore", typeof(int))));
 
-		var condition = new ExpressionConditionNode("hasEnoughScore");
+		var condition = new ExpressionNode("hasEnoughScore");
 		var trueAction = new TrackingActionNode();
 		var falseAction = new TrackingActionNode();
 
@@ -334,7 +334,7 @@ public class ExpressionResolverTests(TagsAndCuesFixture tagsAndCuesFixture) : IC
 				ComparisonOperation.GreaterThanOrEqual,
 				new VariableResolver("required", typeof(int))));
 
-		var condition = new ExpressionConditionNode("hasEnoughAttribute");
+		var condition = new ExpressionNode("hasEnoughAttribute");
 		var trueAction = new TrackingActionNode();
 		var falseAction = new TrackingActionNode();
 

--- a/Forge/Statescript/Node.cs
+++ b/Forge/Statescript/Node.cs
@@ -22,7 +22,7 @@ public abstract class Node
 	/// <summary>
 	/// Gets a description of the node type, which is used in editor tooltips and documentation.
 	/// </summary>
-	public virtual string Description => $"A {GetType().Name.Replace("Node", string.Empty)} node.";
+	public virtual string Description => $"{GetType().Name.Replace("Node", string.Empty)} node.";
 
 	/// <summary>
 	/// Gets or sets the unique identifier for this node.

--- a/Forge/Statescript/Node.cs
+++ b/Forge/Statescript/Node.cs
@@ -20,6 +20,11 @@ public abstract class Node
 	protected abstract void DefinePorts(List<InputPort> inputPorts, List<OutputPort> outputPorts);
 
 	/// <summary>
+	/// Gets a description of the node type, which is used in editor tooltips and documentation.
+	/// </summary>
+	public virtual string Description => $"A {GetType().Name.Replace("Node", string.Empty)} node.";
+
+	/// <summary>
 	/// Gets or sets the unique identifier for this node.
 	/// </summary>
 	public Guid NodeID { get; set; }

--- a/Forge/Statescript/Nodes/Action/SetVariableNode.cs
+++ b/Forge/Statescript/Nodes/Action/SetVariableNode.cs
@@ -24,6 +24,9 @@ public class SetVariableNode(StringKey sourcePropertyName, StringKey targetVaria
 	private readonly StringKey _targetVariableName = targetVariableName;
 
 	/// <inheritdoc/>
+	public override string Description => "Sets a graph variable to the value of a property.";
+
+	/// <inheritdoc/>
 	protected override void Execute(GraphContext graphContext)
 	{
 		if (!graphContext.GraphVariables.TryGetVariant(_sourcePropertyName, graphContext, out Variant128 value))

--- a/Forge/Statescript/Nodes/ActionNode.cs
+++ b/Forge/Statescript/Nodes/ActionNode.cs
@@ -27,6 +27,9 @@ public abstract class ActionNode : Node
 	protected abstract void Execute(GraphContext graphContext);
 
 	/// <inheritdoc/>
+	public override string Description => $"A {GetType().Name.Replace("Node", string.Empty)} action node.";
+
+	/// <inheritdoc/>
 #pragma warning disable SA1202 // Elements should be ordered by access
 	internal override IEnumerable<int> GetReachableOutputPorts(byte inputPortIndex)
 #pragma warning restore SA1202 // Elements should be ordered by access

--- a/Forge/Statescript/Nodes/Condition/ExpressionConditionNode.cs
+++ b/Forge/Statescript/Nodes/Condition/ExpressionConditionNode.cs
@@ -17,7 +17,7 @@ namespace Gamesmiths.Forge.Statescript.Nodes.Condition;
 /// </remarks>
 /// <param name="conditionPropertyName">The name of the graph property that provides the condition result. Must resolve
 /// to a <see langword="bool"/> value.</param>
-public class ExpressionConditionNode(StringKey conditionPropertyName) : ConditionNode
+public class ExpressionNode(StringKey conditionPropertyName) : ConditionNode
 {
 	private readonly StringKey _conditionPropertyName = conditionPropertyName;
 

--- a/Forge/Statescript/Nodes/Condition/ExpressionNode.cs
+++ b/Forge/Statescript/Nodes/Condition/ExpressionNode.cs
@@ -22,6 +22,9 @@ public class ExpressionNode(StringKey conditionPropertyName) : ConditionNode
 	private readonly StringKey _conditionPropertyName = conditionPropertyName;
 
 	/// <inheritdoc/>
+	public override string Description => "Evaluates the given property to determine which port to activate.";
+
+	/// <inheritdoc/>
 	protected override bool Test(GraphContext graphContext)
 	{
 		if (!graphContext.GraphVariables.TryGet(_conditionPropertyName, graphContext, out bool result))

--- a/Forge/Statescript/Nodes/ConditionNode.cs
+++ b/Forge/Statescript/Nodes/ConditionNode.cs
@@ -33,6 +33,9 @@ public abstract class ConditionNode : Node
 	protected abstract bool Test(GraphContext graphContext);
 
 	/// <inheritdoc/>
+	public override string Description => $"A {GetType().Name.Replace("Node", string.Empty)} condition node.";
+
+	/// <inheritdoc/>
 #pragma warning disable SA1202 // Elements should be ordered by access
 	internal override IEnumerable<int> GetReachableOutputPorts(byte inputPortIndex)
 #pragma warning restore SA1202 // Elements should be ordered by access

--- a/Forge/Statescript/Nodes/EntryNode.cs
+++ b/Forge/Statescript/Nodes/EntryNode.cs
@@ -15,6 +15,9 @@ public class EntryNode : Node
 	/// </summary>
 	public const byte OutputPort = 0;
 
+	/// <inheritdoc/>
+	public override string Description => "Entry point of the graph. Emits a message to start execution.";
+
 	/// <summary>
 	/// Starts the graph execution by emitting a message through the output port.
 	/// </summary>

--- a/Forge/Statescript/Nodes/ExitNode.cs
+++ b/Forge/Statescript/Nodes/ExitNode.cs
@@ -20,6 +20,9 @@ public class ExitNode : Node
 	public const byte InputPort = 0;
 
 	/// <inheritdoc/>
+	public override string Description => "Exit point of the graph. Stops execution when a message is received.";
+
+	/// <inheritdoc/>
 	internal override IEnumerable<int> GetReachableOutputPorts(byte inputPortIndex)
 	{
 		return [];

--- a/Forge/Statescript/Nodes/State/TimerNode.cs
+++ b/Forge/Statescript/Nodes/State/TimerNode.cs
@@ -22,6 +22,9 @@ public class TimerNode(StringKey durationPropertyName) : StateNode<TimerNodeCont
 	private readonly StringKey _durationPropertyName = durationPropertyName;
 
 	/// <inheritdoc/>
+	public override string Description => "Remains active for a configured duration, then deactivates.";
+
+	/// <inheritdoc/>
 	protected override void OnActivate(GraphContext graphContext)
 	{
 		TimerNodeContext nodeContext = graphContext.GetNodeContext<TimerNodeContext>(NodeID);

--- a/Forge/Statescript/Nodes/StateNode.cs
+++ b/Forge/Statescript/Nodes/StateNode.cs
@@ -57,6 +57,9 @@ public abstract class StateNode<T> : Node
 	/// <param name="graphContext">The graph's context.</param>
 	protected abstract void OnDeactivate(GraphContext graphContext);
 
+	/// <inheritdoc/>
+	public override string Description => $"A {GetType().Name.Replace("Node", string.Empty)} state node.";
+
 	/// <summary>
 	/// Updates this state node with the given delta time. Only processes the update if the node is currently active.
 	/// </summary>


### PR DESCRIPTION
Added description field to nodes so editor tools can use that to help users understand what the nodes are used for.

Simplified the name of ExpressionCondition node to Expression node only. Our standard should keep out the words Action, Condition and State from the node names for the sake of simpler names.