### PR TITLE
Added math library resolvers.

### DIFF
--- a/Forge.Tests/Helpers/StatescriptTestHelpers.cs
+++ b/Forge.Tests/Helpers/StatescriptTestHelpers.cs
@@ -278,3 +278,56 @@ internal sealed class ReadArrayPropertyNode : ActionNode
 		LastReadArray = resolved;
 	}
 }
+
+internal sealed class FixedRandom(int nextInt = 0, float nextSingle = 0.0f, double nextDouble = 0.0) : IRandom
+{
+	public int NextInt()
+	{
+		return nextInt;
+	}
+
+	public int NextInt(int maxValue)
+	{
+		return nextInt;
+	}
+
+	public int NextInt(int minValue, int maxValue)
+	{
+		return nextInt;
+	}
+
+	public float NextSingle()
+	{
+		return nextSingle;
+	}
+
+	public double NextDouble()
+	{
+		return nextDouble;
+	}
+
+	public long NextInt64()
+	{
+		throw new NotImplementedException();
+	}
+
+	public long NextInt64(long maxValue)
+	{
+		throw new NotImplementedException();
+	}
+
+	public long NextInt64(long minValue, long maxValue)
+	{
+		throw new NotImplementedException();
+	}
+
+	public void NextBytes(byte[] buffer)
+	{
+		throw new NotImplementedException();
+	}
+
+	public void NextBytes(Span<byte> buffer)
+	{
+		throw new NotImplementedException();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/ACosHResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/ACosHResolverTests.cs
@@ -1,0 +1,115 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class ACosHResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "ACosH")]
+	public void ACosH_resolver_float_value_type_is_float()
+	{
+		var resolver = new ACosHResolver(
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "ACosH")]
+	public void ACosH_resolver_double_value_type_is_double()
+	{
+		var resolver = new ACosHResolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "ACosH")]
+	public void ACosH_resolver_int_promotes_to_double()
+	{
+		var resolver = new ACosHResolver(
+			new VariantResolver(new Variant128(1), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "ACosH")]
+	public void ACosH_resolver_one_returns_zero()
+	{
+		// ACosH(1) = 0
+		var resolver = new ACosHResolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(0.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ACosH")]
+	public void ACosH_resolver_two()
+	{
+		// ACosH(2) ≈ 1.3170
+		var resolver = new ACosHResolver(
+			new VariantResolver(new Variant128(2.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(1.3170, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ACosH")]
+	public void ACosH_resolver_float_computation()
+	{
+		var resolver = new ACosHResolver(
+			new VariantResolver(new Variant128(2.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().BeApproximately(1.317f, 0.01f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ACosH")]
+	public void ACosH_resolver_throws_for_decimal_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ACosHResolver(
+			new VariantResolver(new Variant128(2.0m), typeof(decimal)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "ACosH")]
+	public void ACosH_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ACosHResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "ACosH")]
+	public void ACosH_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ACosHResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/ACosResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/ACosResolverTests.cs
@@ -1,0 +1,141 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class ACosResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "ACos")]
+	public void ACos_resolver_float_value_type_is_float()
+	{
+		var resolver = new ACosResolver(
+			new VariantResolver(new Variant128(0.5f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "ACos")]
+	public void ACos_resolver_double_value_type_is_double()
+	{
+		var resolver = new ACosResolver(
+			new VariantResolver(new Variant128(0.5), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "ACos")]
+	public void ACos_resolver_int_promotes_to_double()
+	{
+		var resolver = new ACosResolver(
+			new VariantResolver(new Variant128(1), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "ACos")]
+	public void ACos_resolver_one_returns_zero()
+	{
+		// ACos(1) = 0
+		var resolver = new ACosResolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(0.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ACos")]
+	public void ACos_resolver_zero_returns_pi_over_2()
+	{
+		// ACos(0) = π/2
+		var resolver = new ACosResolver(
+			new VariantResolver(new Variant128(0.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(Math.PI / 2.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ACos")]
+	public void ACos_resolver_negative_one_returns_pi()
+	{
+		// ACos(-1) = π
+		var resolver = new ACosResolver(
+			new VariantResolver(new Variant128(-1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(Math.PI, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ACos")]
+	public void ACos_resolver_half_returns_pi_over_3()
+	{
+		// ACos(0.5) = π/3
+		var resolver = new ACosResolver(
+			new VariantResolver(new Variant128(0.5), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(Math.PI / 3.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ACos")]
+	public void ACos_resolver_float_computation()
+	{
+		var resolver = new ACosResolver(
+			new VariantResolver(new Variant128(0.5f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().BeApproximately(MathF.PI / 3.0f, 0.001f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ACos")]
+	public void ACos_resolver_throws_for_decimal_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ACosResolver(
+			new VariantResolver(new Variant128(0.5m), typeof(decimal)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "ACos")]
+	public void ACos_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ACosResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "ACos")]
+	public void ACos_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ACosResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/ASinHResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/ASinHResolverTests.cs
@@ -1,0 +1,128 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class ASinHResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "ASinH")]
+	public void ASinH_resolver_float_value_type_is_float()
+	{
+		var resolver = new ASinHResolver(
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "ASinH")]
+	public void ASinH_resolver_double_value_type_is_double()
+	{
+		var resolver = new ASinHResolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "ASinH")]
+	public void ASinH_resolver_int_promotes_to_double()
+	{
+		var resolver = new ASinHResolver(
+			new VariantResolver(new Variant128(0), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "ASinH")]
+	public void ASinH_resolver_zero_returns_zero()
+	{
+		// ASinH(0) = 0
+		var resolver = new ASinHResolver(
+			new VariantResolver(new Variant128(0.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(0.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ASinH")]
+	public void ASinH_resolver_one()
+	{
+		// ASinH(1) ≈ 0.8814
+		var resolver = new ASinHResolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(0.8814, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ASinH")]
+	public void ASinH_resolver_negative_value()
+	{
+		// ASinH is an odd function: ASinH(-1) ≈ -0.8814
+		var resolver = new ASinHResolver(
+			new VariantResolver(new Variant128(-1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(-0.8814, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ASinH")]
+	public void ASinH_resolver_float_computation()
+	{
+		var resolver = new ASinHResolver(
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().BeApproximately(0.8814f, 0.01f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ASinH")]
+	public void ASinH_resolver_throws_for_decimal_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ASinHResolver(
+			new VariantResolver(new Variant128(1.0m), typeof(decimal)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "ASinH")]
+	public void ASinH_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ASinHResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "ASinH")]
+	public void ASinH_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ASinHResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/ASinResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/ASinResolverTests.cs
@@ -1,0 +1,141 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class ASinResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "ASin")]
+	public void ASin_resolver_float_value_type_is_float()
+	{
+		var resolver = new ASinResolver(
+			new VariantResolver(new Variant128(0.5f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "ASin")]
+	public void ASin_resolver_double_value_type_is_double()
+	{
+		var resolver = new ASinResolver(
+			new VariantResolver(new Variant128(0.5), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "ASin")]
+	public void ASin_resolver_int_promotes_to_double()
+	{
+		var resolver = new ASinResolver(
+			new VariantResolver(new Variant128(0), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "ASin")]
+	public void ASin_resolver_zero_returns_zero()
+	{
+		// ASin(0) = 0
+		var resolver = new ASinResolver(
+			new VariantResolver(new Variant128(0.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(0.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ASin")]
+	public void ASin_resolver_one_returns_pi_over_2()
+	{
+		// ASin(1) = π/2
+		var resolver = new ASinResolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(Math.PI / 2.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ASin")]
+	public void ASin_resolver_negative_one_returns_negative_pi_over_2()
+	{
+		// ASin(-1) = -π/2
+		var resolver = new ASinResolver(
+			new VariantResolver(new Variant128(-1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(-Math.PI / 2.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ASin")]
+	public void ASin_resolver_half_returns_pi_over_6()
+	{
+		// ASin(0.5) = π/6
+		var resolver = new ASinResolver(
+			new VariantResolver(new Variant128(0.5), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(Math.PI / 6.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ASin")]
+	public void ASin_resolver_float_computation()
+	{
+		var resolver = new ASinResolver(
+			new VariantResolver(new Variant128(0.5f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().BeApproximately(MathF.PI / 6.0f, 0.001f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ASin")]
+	public void ASin_resolver_throws_for_decimal_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ASinResolver(
+			new VariantResolver(new Variant128(0.5m), typeof(decimal)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "ASin")]
+	public void ASin_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ASinResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "ASin")]
+	public void ASin_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ASinResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/ATan2ResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/ATan2ResolverTests.cs
@@ -1,0 +1,170 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class ATan2ResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "ATan2")]
+	public void ATan2_resolver_float_operands_value_type_is_float()
+	{
+		var resolver = new ATan2Resolver(
+			new VariantResolver(new Variant128(1.0f), typeof(float)),
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATan2")]
+	public void ATan2_resolver_double_operands_value_type_is_double()
+	{
+		var resolver = new ATan2Resolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)),
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATan2")]
+	public void ATan2_resolver_int_operands_promotes_to_double()
+	{
+		var resolver = new ATan2Resolver(
+			new VariantResolver(new Variant128(1), typeof(int)),
+			new VariantResolver(new Variant128(1), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATan2")]
+	public void ATan2_resolver_one_one_returns_pi_over_4()
+	{
+		// ATan2(1, 1) = π/4
+		var resolver = new ATan2Resolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)),
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(Math.PI / 4.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATan2")]
+	public void ATan2_resolver_zero_positive_returns_zero()
+	{
+		// ATan2(0, 1) = 0
+		var resolver = new ATan2Resolver(
+			new VariantResolver(new Variant128(0.0), typeof(double)),
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(0.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATan2")]
+	public void ATan2_resolver_positive_zero_returns_pi_over_2()
+	{
+		// ATan2(1, 0) = π/2
+		var resolver = new ATan2Resolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)),
+			new VariantResolver(new Variant128(0.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(Math.PI / 2.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATan2")]
+	public void ATan2_resolver_negative_y_negative_x()
+	{
+		// ATan2(-1, -1) = -3π/4
+		var resolver = new ATan2Resolver(
+			new VariantResolver(new Variant128(-1.0), typeof(double)),
+			new VariantResolver(new Variant128(-1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(-3.0 * Math.PI / 4.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATan2")]
+	public void ATan2_resolver_float_computation()
+	{
+		var resolver = new ATan2Resolver(
+			new VariantResolver(new Variant128(1.0f), typeof(float)),
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().BeApproximately(MathF.PI / 4.0f, 0.001f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATan2")]
+	public void ATan2_resolver_supports_nesting()
+	{
+		// ATan2(ATan2(1, 1), 1) = ATan2(π/4, 1) ≈ ATan2(0.7854, 1) ≈ 0.6658
+		var inner = new ATan2Resolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)),
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		var outer = new ATan2Resolver(
+			inner,
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		outer.Resolve(context).AsDouble().Should().BeApproximately(0.6658, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATan2")]
+	public void ATan2_resolver_throws_for_decimal_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ATan2Resolver(
+			new VariantResolver(new Variant128(1.0m), typeof(decimal)),
+			new VariantResolver(new Variant128(1.0m), typeof(decimal)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATan2")]
+	public void ATan2_resolver_throws_for_vector_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ATan2Resolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)),
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATan2")]
+	public void ATan2_resolver_throws_for_bool_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ATan2Resolver(
+			new VariantResolver(new Variant128(true), typeof(bool)),
+			new VariantResolver(new Variant128(false), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/ATanHResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/ATanHResolverTests.cs
@@ -1,0 +1,128 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class ATanHResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "ATanH")]
+	public void ATanH_resolver_float_value_type_is_float()
+	{
+		var resolver = new ATanHResolver(
+			new VariantResolver(new Variant128(0.5f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATanH")]
+	public void ATanH_resolver_double_value_type_is_double()
+	{
+		var resolver = new ATanHResolver(
+			new VariantResolver(new Variant128(0.5), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATanH")]
+	public void ATanH_resolver_int_promotes_to_double()
+	{
+		var resolver = new ATanHResolver(
+			new VariantResolver(new Variant128(0), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATanH")]
+	public void ATanH_resolver_zero_returns_zero()
+	{
+		// ATanH(0) = 0
+		var resolver = new ATanHResolver(
+			new VariantResolver(new Variant128(0.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(0.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATanH")]
+	public void ATanH_resolver_half()
+	{
+		// ATanH(0.5) ≈ 0.5493
+		var resolver = new ATanHResolver(
+			new VariantResolver(new Variant128(0.5), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(0.5493, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATanH")]
+	public void ATanH_resolver_negative_half()
+	{
+		// ATanH is odd: ATanH(-0.5) ≈ -0.5493
+		var resolver = new ATanHResolver(
+			new VariantResolver(new Variant128(-0.5), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(-0.5493, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATanH")]
+	public void ATanH_resolver_float_computation()
+	{
+		var resolver = new ATanHResolver(
+			new VariantResolver(new Variant128(0.5f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().BeApproximately(0.5493f, 0.01f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATanH")]
+	public void ATanH_resolver_throws_for_decimal_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ATanHResolver(
+			new VariantResolver(new Variant128(0.5m), typeof(decimal)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATanH")]
+	public void ATanH_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ATanHResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATanH")]
+	public void ATanH_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ATanHResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/ATanResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/ATanResolverTests.cs
@@ -1,0 +1,141 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class ATanResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "ATan")]
+	public void ATan_resolver_float_value_type_is_float()
+	{
+		var resolver = new ATanResolver(
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATan")]
+	public void ATan_resolver_double_value_type_is_double()
+	{
+		var resolver = new ATanResolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATan")]
+	public void ATan_resolver_int_promotes_to_double()
+	{
+		var resolver = new ATanResolver(
+			new VariantResolver(new Variant128(1), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATan")]
+	public void ATan_resolver_zero_returns_zero()
+	{
+		var resolver = new ATanResolver(
+			new VariantResolver(new Variant128(0.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(0.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATan")]
+	public void ATan_resolver_one_returns_pi_over_4()
+	{
+		// ATan(1) = π/4
+		var resolver = new ATanResolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(Math.PI / 4.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATan")]
+	public void ATan_resolver_negative_one_returns_negative_pi_over_4()
+	{
+		var resolver = new ATanResolver(
+			new VariantResolver(new Variant128(-1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(-Math.PI / 4.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATan")]
+	public void ATan_resolver_float_precision()
+	{
+		var resolver = new ATanResolver(
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().BeApproximately(MathF.PI / 4.0f, 0.001f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATan")]
+	public void ATan_resolver_supports_nesting()
+	{
+		// ATan(ATan(1.0)) = ATan(π/4) ≈ ATan(0.7854) ≈ 0.6658
+		var inner = new ATanResolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		var outer = new ATanResolver(inner);
+
+		var context = new GraphContext();
+
+		outer.Resolve(context).AsDouble().Should().BeApproximately(0.6658, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATan")]
+	public void ATan_resolver_throws_for_decimal_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ATanResolver(
+			new VariantResolver(new Variant128(1.0m), typeof(decimal)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATan")]
+	public void ATan_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ATanResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "ATan")]
+	public void ATan_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ATanResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/AbsResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/AbsResolverTests.cs
@@ -1,0 +1,260 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class AbsResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Abs")]
+	public void Abs_resolver_int_value_type_is_int()
+	{
+		var resolver = new AbsResolver(
+			new VariantResolver(new Variant128(-5), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(int));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Abs")]
+	public void Abs_resolver_double_value_type_is_double()
+	{
+		var resolver = new AbsResolver(
+			new VariantResolver(new Variant128(-5.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Abs")]
+	public void Abs_resolver_sbyte_promotes_to_int()
+	{
+		var resolver = new AbsResolver(
+			new VariantResolver(new Variant128((sbyte)-10), typeof(sbyte)));
+
+		resolver.ValueType.Should().Be(typeof(int));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Abs")]
+	public void Abs_resolver_short_promotes_to_int()
+	{
+		var resolver = new AbsResolver(
+			new VariantResolver(new Variant128((short)-100), typeof(short)));
+
+		resolver.ValueType.Should().Be(typeof(int));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Abs")]
+	public void Abs_resolver_negative_int_returns_positive()
+	{
+		var resolver = new AbsResolver(
+			new VariantResolver(new Variant128(-42), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(42);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Abs")]
+	public void Abs_resolver_positive_int_returns_same()
+	{
+		var resolver = new AbsResolver(
+			new VariantResolver(new Variant128(42), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(42);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Abs")]
+	public void Abs_resolver_negative_double_returns_positive()
+	{
+		var resolver = new AbsResolver(
+			new VariantResolver(new Variant128(-3.14), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(3.14);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Abs")]
+	public void Abs_resolver_negative_float_returns_positive()
+	{
+		var resolver = new AbsResolver(
+			new VariantResolver(new Variant128(-2.5f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(2.5f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Abs")]
+	public void Abs_resolver_negative_long_returns_positive()
+	{
+		var resolver = new AbsResolver(
+			new VariantResolver(new Variant128(-100L), typeof(long)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsLong().Should().Be(100L);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Abs")]
+	public void Abs_resolver_negative_decimal_returns_positive()
+	{
+		var resolver = new AbsResolver(
+			new VariantResolver(new Variant128(-7.5m), typeof(decimal)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDecimal().Should().Be(7.5m);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Abs")]
+	public void Abs_resolver_negative_sbyte_returns_positive_int()
+	{
+		var resolver = new AbsResolver(
+			new VariantResolver(new Variant128((sbyte)-10), typeof(sbyte)));
+
+		var context = new GraphContext();
+
+		// sbyte promotes to int
+		resolver.Resolve(context).AsInt().Should().Be(10);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Abs")]
+	public void Abs_resolver_negative_short_returns_positive_int()
+	{
+		var resolver = new AbsResolver(
+			new VariantResolver(new Variant128((short)-200), typeof(short)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(200);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Abs")]
+	public void Abs_resolver_zero_returns_zero()
+	{
+		var resolver = new AbsResolver(
+			new VariantResolver(new Variant128(0), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Abs")]
+	public void Abs_resolver_composes_with_subtract()
+	{
+		// Abs(3 - 10) = Abs(-7) = 7
+		var subtract = new SubtractResolver(
+			new VariantResolver(new Variant128(3), typeof(int)),
+			new VariantResolver(new Variant128(10), typeof(int)));
+
+		var abs = new AbsResolver(subtract);
+
+		var context = new GraphContext();
+
+		abs.Resolve(context).AsInt().Should().Be(7);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Abs")]
+	public void Abs_resolver_throws_for_unsigned_byte()
+	{
+#pragma warning disable CA1806
+		Action act = () => new AbsResolver(
+			new VariantResolver(new Variant128((byte)10), typeof(byte)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Abs")]
+	public void Abs_resolver_throws_for_unsigned_ushort()
+	{
+#pragma warning disable CA1806
+		Action act = () => new AbsResolver(
+			new VariantResolver(new Variant128((ushort)10), typeof(ushort)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Abs")]
+	public void Abs_resolver_throws_for_unsigned_uint()
+	{
+#pragma warning disable CA1806
+		Action act = () => new AbsResolver(
+			new VariantResolver(new Variant128(10u), typeof(uint)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Abs")]
+	public void Abs_resolver_throws_for_unsigned_ulong()
+	{
+#pragma warning disable CA1806
+		Action act = () => new AbsResolver(
+			new VariantResolver(new Variant128(10UL), typeof(ulong)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Abs")]
+	public void Abs_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new AbsResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Abs")]
+	public void Abs_resolver_throws_for_quaternion_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new AbsResolver(
+			new VariantResolver(new Variant128(Quaternion.Identity), typeof(Quaternion)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Abs")]
+	public void Abs_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new AbsResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/AddResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/AddResolverTests.cs
@@ -1,0 +1,715 @@
+// Copyright © Gamesmiths Guild.
+
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class AddResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_int_plus_int_value_type_is_int()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(1), typeof(int)),
+			new VariantResolver(new Variant128(2), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(int));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_float_plus_float_value_type_is_float()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(1.0f), typeof(float)),
+			new VariantResolver(new Variant128(2.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_double_plus_double_value_type_is_double()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)),
+			new VariantResolver(new Variant128(2.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_vector2_plus_vector2_value_type_is_vector2()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(Vector2.One), typeof(Vector2)),
+			new VariantResolver(new Variant128(Vector2.One), typeof(Vector2)));
+
+		resolver.ValueType.Should().Be(typeof(Vector2));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_vector3_plus_vector3_value_type_is_vector3()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)),
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+
+		resolver.ValueType.Should().Be(typeof(Vector3));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_vector4_plus_vector4_value_type_is_vector4()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(Vector4.One), typeof(Vector4)),
+			new VariantResolver(new Variant128(Vector4.One), typeof(Vector4)));
+
+		resolver.ValueType.Should().Be(typeof(Vector4));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_quaternion_plus_quaternion_value_type_is_quaternion()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(Quaternion.Identity), typeof(Quaternion)),
+			new VariantResolver(new Variant128(Quaternion.Identity), typeof(Quaternion)));
+
+		resolver.ValueType.Should().Be(typeof(Quaternion));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_int_plus_float_promotes_to_float()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(1), typeof(int)),
+			new VariantResolver(new Variant128(2.5f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_int_plus_double_promotes_to_double()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(1), typeof(int)),
+			new VariantResolver(new Variant128(2.5), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_float_plus_double_promotes_to_double()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(1.0f), typeof(float)),
+			new VariantResolver(new Variant128(2.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_byte_plus_short_promotes_to_int()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128((byte)1), typeof(byte)),
+			new VariantResolver(new Variant128((short)2), typeof(short)));
+
+		resolver.ValueType.Should().Be(typeof(int));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_int_plus_uint_promotes_to_long()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(1), typeof(int)),
+			new VariantResolver(new Variant128(2u), typeof(uint)));
+
+		resolver.ValueType.Should().Be(typeof(long));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_long_plus_long_value_type_is_long()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(1L), typeof(long)),
+			new VariantResolver(new Variant128(2L), typeof(long)));
+
+		resolver.ValueType.Should().Be(typeof(long));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_ulong_plus_int_promotes_to_double()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(1UL), typeof(ulong)),
+			new VariantResolver(new Variant128(2), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_decimal_plus_int_promotes_to_decimal()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(1.0m), typeof(decimal)),
+			new VariantResolver(new Variant128(2), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(decimal));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_adds_two_ints()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(20), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(30);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_adds_two_floats()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(1.5f), typeof(float)),
+			new VariantResolver(new Variant128(2.5f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(4.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_adds_two_doubles()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(1.5), typeof(double)),
+			new VariantResolver(new Variant128(2.5), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(4.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_adds_two_longs()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(100L), typeof(long)),
+			new VariantResolver(new Variant128(200L), typeof(long)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsLong().Should().Be(300L);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_adds_two_decimals()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(1.1m), typeof(decimal)),
+			new VariantResolver(new Variant128(2.2m), typeof(decimal)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDecimal().Should().Be(3.3m);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_adds_two_bytes()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128((byte)10), typeof(byte)),
+			new VariantResolver(new Variant128((byte)20), typeof(byte)));
+
+		var context = new GraphContext();
+
+		// byte + byte promotes to int
+		resolver.Resolve(context).AsInt().Should().Be(30);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_adds_two_shorts()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128((short)100), typeof(short)),
+			new VariantResolver(new Variant128((short)200), typeof(short)));
+
+		var context = new GraphContext();
+
+		// short + short promotes to int
+		resolver.Resolve(context).AsInt().Should().Be(300);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_adds_two_sbytes()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128((sbyte)10), typeof(sbyte)),
+			new VariantResolver(new Variant128((sbyte)20), typeof(sbyte)));
+
+		var context = new GraphContext();
+
+		// sbyte + sbyte promotes to int
+		resolver.Resolve(context).AsInt().Should().Be(30);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_adds_two_ushorts()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128((ushort)100), typeof(ushort)),
+			new VariantResolver(new Variant128((ushort)200), typeof(ushort)));
+
+		var context = new GraphContext();
+
+		// ushort + ushort promotes to int
+		resolver.Resolve(context).AsInt().Should().Be(300);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_adds_two_uints()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(100u), typeof(uint)),
+			new VariantResolver(new Variant128(200u), typeof(uint)));
+
+		var context = new GraphContext();
+
+		// uint + uint → long (promotion to avoid overflow)
+		resolver.Resolve(context).AsLong().Should().Be(300L);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_adds_two_ulongs()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(100UL), typeof(ulong)),
+			new VariantResolver(new Variant128(200UL), typeof(ulong)));
+
+		var context = new GraphContext();
+
+		// ulong + ulong → double (promotion since there's no wider integer type)
+		resolver.Resolve(context).AsDouble().Should().Be(300.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_adds_int_and_float()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(2.5f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(12.5f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_adds_float_and_int()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(2.5f), typeof(float)),
+			new VariantResolver(new Variant128(10), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(12.5f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_adds_int_and_double()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(2.5), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(12.5);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_adds_float_and_double()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(1.5f), typeof(float)),
+			new VariantResolver(new Variant128(2.5), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(4.0, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_adds_byte_and_int()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128((byte)5), typeof(byte)),
+			new VariantResolver(new Variant128(100), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(105);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_adds_short_and_long()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128((short)5), typeof(short)),
+			new VariantResolver(new Variant128(1000L), typeof(long)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsLong().Should().Be(1005L);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_adds_int_and_decimal()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(2.5m), typeof(decimal)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDecimal().Should().Be(12.5m);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_adds_two_vector2()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(new Vector2(1, 2)), typeof(Vector2)),
+			new VariantResolver(new Variant128(new Vector2(3, 4)), typeof(Vector2)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector2().Should().Be(new Vector2(4, 6));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_adds_two_vector3()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(new Vector3(1, 2, 3)), typeof(Vector3)),
+			new VariantResolver(new Variant128(new Vector3(4, 5, 6)), typeof(Vector3)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector3().Should().Be(new Vector3(5, 7, 9));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_adds_two_vector4()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(new Vector4(1, 2, 3, 4)), typeof(Vector4)),
+			new VariantResolver(new Variant128(new Vector4(5, 6, 7, 8)), typeof(Vector4)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector4().Should().Be(new Vector4(6, 8, 10, 12));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_adds_two_quaternions()
+	{
+		var left = new Quaternion(1, 2, 3, 4);
+		var right = new Quaternion(5, 6, 7, 8);
+
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(left), typeof(Quaternion)),
+			new VariantResolver(new Variant128(right), typeof(Quaternion)));
+
+		var context = new GraphContext();
+
+		Quaternion result = resolver.Resolve(context).AsQuaternion();
+		Quaternion expected = left + right;
+
+		result.Should().Be(expected);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_handles_negative_ints()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(-3), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(7);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_handles_negative_result()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(-10.0), typeof(double)),
+			new VariantResolver(new Variant128(-5.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(-15.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_adding_zero_returns_same_value()
+	{
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(42), typeof(int)),
+			new VariantResolver(new Variant128(0), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(42);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_adding_zero_vector_returns_same_vector()
+	{
+		var original = new Vector3(1, 2, 3);
+
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(original), typeof(Vector3)),
+			new VariantResolver(new Variant128(Vector3.Zero), typeof(Vector3)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector3().Should().Be(original);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_supports_nesting()
+	{
+		// (10 + 20) + 30 = 60
+		var innerAdd = new AddResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(20), typeof(int)));
+
+		var outerAdd = new AddResolver(
+			innerAdd,
+			new VariantResolver(new Variant128(30), typeof(int)));
+
+		var context = new GraphContext();
+
+		outerAdd.Resolve(context).AsInt().Should().Be(60);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_nests_with_type_promotion()
+	{
+		// (int 10 + float 2.5f) + double 1.0 = double 13.5
+		var innerAdd = new AddResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(2.5f), typeof(float)));
+
+		innerAdd.ValueType.Should().Be(typeof(float));
+
+		var outerAdd = new AddResolver(
+			innerAdd,
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		outerAdd.ValueType.Should().Be(typeof(double));
+
+		var context = new GraphContext();
+
+		outerAdd.Resolve(context).AsDouble().Should().BeApproximately(13.5, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_nests_vector_additions()
+	{
+		// (1,0) + (0,1) + (2,3) = (3,4)
+		var innerAdd = new AddResolver(
+			new VariantResolver(new Variant128(new Vector2(1, 0)), typeof(Vector2)),
+			new VariantResolver(new Variant128(new Vector2(0, 1)), typeof(Vector2)));
+
+		var outerAdd = new AddResolver(
+			innerAdd,
+			new VariantResolver(new Variant128(new Vector2(2, 3)), typeof(Vector2)));
+
+		var context = new GraphContext();
+
+		outerAdd.Resolve(context).AsVector2().Should().Be(new Vector2(3, 4));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_works_with_variable_resolver()
+	{
+		var graph = new Graph();
+		graph.VariableDefinitions.DefineVariable("speed", 5.0);
+
+		var context = new GraphContext();
+		context.GraphVariables.InitializeFrom(graph.VariableDefinitions);
+
+		var resolver = new AddResolver(
+			new VariableResolver("speed", typeof(double)),
+			new VariantResolver(new Variant128(2.5), typeof(double)));
+
+		resolver.Resolve(context).AsDouble().Should().Be(7.5);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_reflects_runtime_variable_changes()
+	{
+		var graph = new Graph();
+		graph.VariableDefinitions.DefineVariable("base", 10.0);
+
+		var context = new GraphContext();
+		context.GraphVariables.InitializeFrom(graph.VariableDefinitions);
+
+		var resolver = new AddResolver(
+			new VariableResolver("base", typeof(double)),
+			new VariantResolver(new Variant128(5.0), typeof(double)));
+
+		resolver.Resolve(context).AsDouble().Should().Be(15.0);
+
+		context.GraphVariables.SetVar("base", 20.0);
+
+		resolver.Resolve(context).AsDouble().Should().Be(25.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_composes_with_comparison_resolver()
+	{
+		// (3 + 4) > 5 → true
+		var addResolver = new AddResolver(
+			new VariantResolver(new Variant128(3), typeof(int)),
+			new VariantResolver(new Variant128(4), typeof(int)));
+
+		var comparisonResolver = new ComparisonResolver(
+			addResolver,
+			ComparisonOperation.GreaterThan,
+			new VariantResolver(new Variant128(5), typeof(int)));
+
+		var context = new GraphContext();
+
+		comparisonResolver.Resolve(context).AsBool().Should().BeTrue();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_throws_for_bool_operands()
+	{
+#pragma warning disable CA1806 // Do not ignore method results
+		Action act = () => new AddResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)),
+			new VariantResolver(new Variant128(false), typeof(bool)));
+#pragma warning restore CA1806 // Do not ignore method results
+
+		act.Should().Throw<ArgumentException>()
+			.WithMessage("*bool*");
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_throws_for_mismatched_vector_types()
+	{
+#pragma warning disable CA1806 // Do not ignore method results
+		Action act = () => new AddResolver(
+			new VariantResolver(new Variant128(Vector2.One), typeof(Vector2)),
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806 // Do not ignore method results
+
+		act.Should().Throw<ArgumentException>()
+			.WithMessage("*vector*");
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_throws_for_vector_and_numeric_mix()
+	{
+#pragma warning disable CA1806 // Do not ignore method results
+		Action act = () => new AddResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)),
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+#pragma warning restore CA1806 // Do not ignore method results
+
+		act.Should().Throw<ArgumentException>()
+			.WithMessage("*vector*");
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_throws_for_char_operands()
+	{
+#pragma warning disable CA1806 // Do not ignore method results
+		Action act = () => new AddResolver(
+			new VariantResolver(new Variant128('A'), typeof(char)),
+			new VariantResolver(new Variant128('B'), typeof(char)));
+#pragma warning restore CA1806 // Do not ignore method results
+
+		act.Should().Throw<ArgumentException>()
+			.WithMessage("*char*");
+	}
+
+	[Fact]
+	[Trait("Resolver", "Add")]
+	public void Add_resolver_throws_for_quaternion_and_vector_mix()
+	{
+#pragma warning disable CA1806 // Do not ignore method results
+		Action act = () => new AddResolver(
+			new VariantResolver(new Variant128(Quaternion.Identity), typeof(Quaternion)),
+			new VariantResolver(new Variant128(Vector4.One), typeof(Vector4)));
+#pragma warning restore CA1806 // Do not ignore method results
+
+		act.Should().Throw<ArgumentException>()
+			.WithMessage("*vector*");
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/AddResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/AddResolverTests.cs
@@ -1,7 +1,5 @@
 // Copyright © Gamesmiths Guild.
 
-// Copyright © Gamesmiths Guild.
-
 using System.Numerics;
 using FluentAssertions;
 using Gamesmiths.Forge.Statescript;

--- a/Forge.Tests/Statescript/Resolvers/CbrtResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/CbrtResolverTests.cs
@@ -1,0 +1,165 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class CbrtResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Cbrt")]
+	public void Cbrt_resolver_float_value_type_is_float()
+	{
+		var resolver = new CbrtResolver(
+			new VariantResolver(new Variant128(8.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Cbrt")]
+	public void Cbrt_resolver_double_value_type_is_double()
+	{
+		var resolver = new CbrtResolver(
+			new VariantResolver(new Variant128(8.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Cbrt")]
+	public void Cbrt_resolver_int_promotes_to_double()
+	{
+		var resolver = new CbrtResolver(
+			new VariantResolver(new Variant128(8), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Cbrt")]
+	public void Cbrt_resolver_computes_float_cbrt()
+	{
+		var resolver = new CbrtResolver(
+			new VariantResolver(new Variant128(27.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().BeApproximately(3.0f, 0.001f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Cbrt")]
+	public void Cbrt_resolver_computes_double_cbrt()
+	{
+		var resolver = new CbrtResolver(
+			new VariantResolver(new Variant128(125.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(5.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Cbrt")]
+	public void Cbrt_resolver_computes_int_cbrt_as_double()
+	{
+		var resolver = new CbrtResolver(
+			new VariantResolver(new Variant128(64), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(4.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Cbrt")]
+	public void Cbrt_resolver_negative_value()
+	{
+		// Cbrt(-8) = -2
+		var resolver = new CbrtResolver(
+			new VariantResolver(new Variant128(-8.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(-2.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Cbrt")]
+	public void Cbrt_resolver_zero_returns_zero()
+	{
+		var resolver = new CbrtResolver(
+			new VariantResolver(new Variant128(0.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(0.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Cbrt")]
+	public void Cbrt_resolver_one_returns_one()
+	{
+		var resolver = new CbrtResolver(
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().BeApproximately(1.0f, 0.001f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Cbrt")]
+	public void Cbrt_resolver_supports_nesting()
+	{
+		// Cbrt(Cbrt(729)) = Cbrt(9) ≈ 2.0801 — wait: Cbrt(729)=9, Cbrt(9)≈2.0801
+		var inner = new CbrtResolver(
+			new VariantResolver(new Variant128(729.0), typeof(double)));
+
+		var outer = new CbrtResolver(inner);
+
+		var context = new GraphContext();
+
+		outer.Resolve(context).AsDouble().Should().BeApproximately(2.0801, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Cbrt")]
+	public void Cbrt_resolver_throws_for_decimal_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new CbrtResolver(
+			new VariantResolver(new Variant128(8.0m), typeof(decimal)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Cbrt")]
+	public void Cbrt_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new CbrtResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Cbrt")]
+	public void Cbrt_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new CbrtResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/CeilResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/CeilResolverTests.cs
@@ -1,0 +1,177 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class CeilResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Ceil")]
+	public void Ceil_resolver_float_value_type_is_float()
+	{
+		var resolver = new CeilResolver(
+			new VariantResolver(new Variant128(2.3f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Ceil")]
+	public void Ceil_resolver_double_value_type_is_double()
+	{
+		var resolver = new CeilResolver(
+			new VariantResolver(new Variant128(2.3), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Ceil")]
+	public void Ceil_resolver_decimal_value_type_is_decimal()
+	{
+		var resolver = new CeilResolver(
+			new VariantResolver(new Variant128(2.3m), typeof(decimal)));
+
+		resolver.ValueType.Should().Be(typeof(decimal));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Ceil")]
+	public void Ceil_resolver_positive_float()
+	{
+		var resolver = new CeilResolver(
+			new VariantResolver(new Variant128(2.3f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(3.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Ceil")]
+	public void Ceil_resolver_negative_float()
+	{
+		var resolver = new CeilResolver(
+			new VariantResolver(new Variant128(-2.7f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(-2.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Ceil")]
+	public void Ceil_resolver_positive_double()
+	{
+		var resolver = new CeilResolver(
+			new VariantResolver(new Variant128(3.01), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(4.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Ceil")]
+	public void Ceil_resolver_negative_double()
+	{
+		var resolver = new CeilResolver(
+			new VariantResolver(new Variant128(-1.9), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(-1.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Ceil")]
+	public void Ceil_resolver_positive_decimal()
+	{
+		var resolver = new CeilResolver(
+			new VariantResolver(new Variant128(5.1m), typeof(decimal)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDecimal().Should().Be(6.0m);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Ceil")]
+	public void Ceil_resolver_negative_decimal()
+	{
+		var resolver = new CeilResolver(
+			new VariantResolver(new Variant128(-5.9m), typeof(decimal)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDecimal().Should().Be(-5.0m);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Ceil")]
+	public void Ceil_resolver_whole_number_returns_same()
+	{
+		var resolver = new CeilResolver(
+			new VariantResolver(new Variant128(5.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(5.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Ceil")]
+	public void Ceil_resolver_supports_nesting()
+	{
+		// Ceil(2.3 + 0.1) = Ceil(2.4) = 3.0
+		var sum = new AddResolver(
+			new VariantResolver(new Variant128(2.3), typeof(double)),
+			new VariantResolver(new Variant128(0.1), typeof(double)));
+
+		var resolver = new CeilResolver(sum);
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(3.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Ceil")]
+	public void Ceil_resolver_throws_for_int_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new CeilResolver(
+			new VariantResolver(new Variant128(5), typeof(int)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Ceil")]
+	public void Ceil_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new CeilResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Ceil")]
+	public void Ceil_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new CeilResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/ClampResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/ClampResolverTests.cs
@@ -1,0 +1,223 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class ClampResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Clamp")]
+	public void Clamp_resolver_all_int_value_type_is_int()
+	{
+		var resolver = new ClampResolver(
+			new VariantResolver(new Variant128(5), typeof(int)),
+			new VariantResolver(new Variant128(0), typeof(int)),
+			new VariantResolver(new Variant128(10), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(int));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Clamp")]
+	public void Clamp_resolver_mixed_int_and_double_promotes_to_double()
+	{
+		var resolver = new ClampResolver(
+			new VariantResolver(new Variant128(5), typeof(int)),
+			new VariantResolver(new Variant128(0.0), typeof(double)),
+			new VariantResolver(new Variant128(10), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Clamp")]
+	public void Clamp_resolver_value_within_range_returns_value()
+	{
+		var resolver = new ClampResolver(
+			new VariantResolver(new Variant128(5), typeof(int)),
+			new VariantResolver(new Variant128(0), typeof(int)),
+			new VariantResolver(new Variant128(10), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(5);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Clamp")]
+	public void Clamp_resolver_value_below_min_returns_min()
+	{
+		var resolver = new ClampResolver(
+			new VariantResolver(new Variant128(-5), typeof(int)),
+			new VariantResolver(new Variant128(0), typeof(int)),
+			new VariantResolver(new Variant128(10), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Clamp")]
+	public void Clamp_resolver_value_above_max_returns_max()
+	{
+		var resolver = new ClampResolver(
+			new VariantResolver(new Variant128(15), typeof(int)),
+			new VariantResolver(new Variant128(0), typeof(int)),
+			new VariantResolver(new Variant128(10), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(10);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Clamp")]
+	public void Clamp_resolver_value_at_min_boundary()
+	{
+		var resolver = new ClampResolver(
+			new VariantResolver(new Variant128(0), typeof(int)),
+			new VariantResolver(new Variant128(0), typeof(int)),
+			new VariantResolver(new Variant128(10), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Clamp")]
+	public void Clamp_resolver_value_at_max_boundary()
+	{
+		var resolver = new ClampResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(0), typeof(int)),
+			new VariantResolver(new Variant128(10), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(10);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Clamp")]
+	public void Clamp_resolver_computes_double_clamp()
+	{
+		var resolver = new ClampResolver(
+			new VariantResolver(new Variant128(1.5), typeof(double)),
+			new VariantResolver(new Variant128(0.0), typeof(double)),
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(1.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Clamp")]
+	public void Clamp_resolver_computes_float_clamp()
+	{
+		var resolver = new ClampResolver(
+			new VariantResolver(new Variant128(-1.0f), typeof(float)),
+			new VariantResolver(new Variant128(0.0f), typeof(float)),
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(0.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Clamp")]
+	public void Clamp_resolver_computes_long_clamp()
+	{
+		var resolver = new ClampResolver(
+			new VariantResolver(new Variant128(200L), typeof(long)),
+			new VariantResolver(new Variant128(0L), typeof(long)),
+			new VariantResolver(new Variant128(100L), typeof(long)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsLong().Should().Be(100L);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Clamp")]
+	public void Clamp_resolver_computes_decimal_clamp()
+	{
+		var resolver = new ClampResolver(
+			new VariantResolver(new Variant128(5.5m), typeof(decimal)),
+			new VariantResolver(new Variant128(1.0m), typeof(decimal)),
+			new VariantResolver(new Variant128(10.0m), typeof(decimal)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDecimal().Should().Be(5.5m);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Clamp")]
+	public void Clamp_resolver_supports_nesting()
+	{
+		// Clamp(Clamp(50, 0, 100), 10, 80) = Clamp(50, 10, 80) = 50
+		var inner = new ClampResolver(
+			new VariantResolver(new Variant128(50), typeof(int)),
+			new VariantResolver(new Variant128(0), typeof(int)),
+			new VariantResolver(new Variant128(100), typeof(int)));
+
+		var outer = new ClampResolver(
+			inner,
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(80), typeof(int)));
+
+		var context = new GraphContext();
+
+		outer.Resolve(context).AsInt().Should().Be(50);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Clamp")]
+	public void Clamp_resolver_throws_for_vector_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ClampResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)),
+			new VariantResolver(new Variant128(Vector3.Zero), typeof(Vector3)),
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Clamp")]
+	public void Clamp_resolver_throws_for_quaternion_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ClampResolver(
+			new VariantResolver(new Variant128(Quaternion.Identity), typeof(Quaternion)),
+			new VariantResolver(new Variant128(Quaternion.Identity), typeof(Quaternion)),
+			new VariantResolver(new Variant128(Quaternion.Identity), typeof(Quaternion)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Clamp")]
+	public void Clamp_resolver_throws_for_bool_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ClampResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)),
+			new VariantResolver(new Variant128(false), typeof(bool)),
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/CopySignResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/CopySignResolverTests.cs
@@ -1,0 +1,185 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class CopySignResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "CopySign")]
+	public void CopySign_resolver_float_operands_value_type_is_float()
+	{
+		var resolver = new CopySignResolver(
+			new VariantResolver(new Variant128(5.0f), typeof(float)),
+			new VariantResolver(new Variant128(-1.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "CopySign")]
+	public void CopySign_resolver_double_operands_value_type_is_double()
+	{
+		var resolver = new CopySignResolver(
+			new VariantResolver(new Variant128(5.0), typeof(double)),
+			new VariantResolver(new Variant128(-1.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "CopySign")]
+	public void CopySign_resolver_int_operands_promotes_to_double()
+	{
+		var resolver = new CopySignResolver(
+			new VariantResolver(new Variant128(5), typeof(int)),
+			new VariantResolver(new Variant128(-1), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "CopySign")]
+	public void CopySign_resolver_positive_magnitude_negative_sign()
+	{
+		// CopySign(5.0, -3.0) = -5.0
+		var resolver = new CopySignResolver(
+			new VariantResolver(new Variant128(5.0), typeof(double)),
+			new VariantResolver(new Variant128(-3.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(-5.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "CopySign")]
+	public void CopySign_resolver_negative_magnitude_positive_sign()
+	{
+		// CopySign(-5.0, 3.0) = 5.0
+		var resolver = new CopySignResolver(
+			new VariantResolver(new Variant128(-5.0), typeof(double)),
+			new VariantResolver(new Variant128(3.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(5.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "CopySign")]
+	public void CopySign_resolver_both_positive()
+	{
+		// CopySign(5.0, 3.0) = 5.0
+		var resolver = new CopySignResolver(
+			new VariantResolver(new Variant128(5.0), typeof(double)),
+			new VariantResolver(new Variant128(3.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(5.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "CopySign")]
+	public void CopySign_resolver_both_negative()
+	{
+		// CopySign(-5.0, -3.0) = -5.0
+		var resolver = new CopySignResolver(
+			new VariantResolver(new Variant128(-5.0), typeof(double)),
+			new VariantResolver(new Variant128(-3.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(-5.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "CopySign")]
+	public void CopySign_resolver_float_computation()
+	{
+		// CopySign(10.0f, -1.0f) = -10.0f
+		var resolver = new CopySignResolver(
+			new VariantResolver(new Variant128(10.0f), typeof(float)),
+			new VariantResolver(new Variant128(-1.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(-10.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "CopySign")]
+	public void CopySign_resolver_zero_magnitude()
+	{
+		// CopySign(0.0, -1.0) = -0.0
+		var resolver = new CopySignResolver(
+			new VariantResolver(new Variant128(0.0), typeof(double)),
+			new VariantResolver(new Variant128(-1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(-0.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "CopySign")]
+	public void CopySign_resolver_supports_nesting()
+	{
+		// CopySign(CopySign(5, -1), 1) = CopySign(-5, 1) = 5
+		var inner = new CopySignResolver(
+			new VariantResolver(new Variant128(5.0), typeof(double)),
+			new VariantResolver(new Variant128(-1.0), typeof(double)));
+
+		var outer = new CopySignResolver(
+			inner,
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		outer.Resolve(context).AsDouble().Should().Be(5.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "CopySign")]
+	public void CopySign_resolver_throws_for_decimal_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new CopySignResolver(
+			new VariantResolver(new Variant128(5.0m), typeof(decimal)),
+			new VariantResolver(new Variant128(-1.0m), typeof(decimal)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "CopySign")]
+	public void CopySign_resolver_throws_for_vector_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new CopySignResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)),
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "CopySign")]
+	public void CopySign_resolver_throws_for_bool_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new CopySignResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)),
+			new VariantResolver(new Variant128(false), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/CosHResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/CosHResolverTests.cs
@@ -1,0 +1,128 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class CosHResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "CosH")]
+	public void CosH_resolver_float_value_type_is_float()
+	{
+		var resolver = new CosHResolver(
+			new VariantResolver(new Variant128(0.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "CosH")]
+	public void CosH_resolver_double_value_type_is_double()
+	{
+		var resolver = new CosHResolver(
+			new VariantResolver(new Variant128(0.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "CosH")]
+	public void CosH_resolver_int_promotes_to_double()
+	{
+		var resolver = new CosHResolver(
+			new VariantResolver(new Variant128(0), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "CosH")]
+	public void CosH_resolver_zero_returns_one()
+	{
+		// CosH(0) = 1
+		var resolver = new CosHResolver(
+			new VariantResolver(new Variant128(0.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(1.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "CosH")]
+	public void CosH_resolver_one()
+	{
+		// CosH(1) ≈ 1.5431
+		var resolver = new CosHResolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(1.5431, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "CosH")]
+	public void CosH_resolver_is_even_function()
+	{
+		// CosH(-1) = CosH(1) ≈ 1.5431
+		var resolver = new CosHResolver(
+			new VariantResolver(new Variant128(-1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(1.5431, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "CosH")]
+	public void CosH_resolver_float_computation()
+	{
+		var resolver = new CosHResolver(
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().BeApproximately(1.5431f, 0.01f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "CosH")]
+	public void CosH_resolver_throws_for_decimal_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new CosHResolver(
+			new VariantResolver(new Variant128(0.0m), typeof(decimal)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "CosH")]
+	public void CosH_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new CosHResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "CosH")]
+	public void CosH_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new CosHResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/CosResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/CosResolverTests.cs
@@ -1,0 +1,141 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class CosResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Cos")]
+	public void Cos_resolver_float_value_type_is_float()
+	{
+		var resolver = new CosResolver(
+			new VariantResolver(new Variant128(0.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Cos")]
+	public void Cos_resolver_double_value_type_is_double()
+	{
+		var resolver = new CosResolver(
+			new VariantResolver(new Variant128(0.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Cos")]
+	public void Cos_resolver_int_promotes_to_double()
+	{
+		var resolver = new CosResolver(
+			new VariantResolver(new Variant128(0), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Cos")]
+	public void Cos_resolver_zero_returns_one()
+	{
+		var resolver = new CosResolver(
+			new VariantResolver(new Variant128(0.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().BeApproximately(1.0f, 0.001f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Cos")]
+	public void Cos_resolver_pi_over_2_returns_zero()
+	{
+		var resolver = new CosResolver(
+			new VariantResolver(new Variant128(Math.PI / 2.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(0.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Cos")]
+	public void Cos_resolver_pi_returns_negative_one()
+	{
+		var resolver = new CosResolver(
+			new VariantResolver(new Variant128(Math.PI), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(-1.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Cos")]
+	public void Cos_resolver_float_pi_over_3()
+	{
+		// Cos(π/3) = 0.5
+		var resolver = new CosResolver(
+			new VariantResolver(new Variant128(MathF.PI / 3.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().BeApproximately(0.5f, 0.001f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Cos")]
+	public void Cos_resolver_supports_nesting()
+	{
+		// Cos(Cos(0)) = Cos(1.0) ≈ 0.5403
+		var inner = new CosResolver(
+			new VariantResolver(new Variant128(0.0), typeof(double)));
+
+		var outer = new CosResolver(inner);
+
+		var context = new GraphContext();
+
+		outer.Resolve(context).AsDouble().Should().BeApproximately(0.5403, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Cos")]
+	public void Cos_resolver_throws_for_decimal_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new CosResolver(
+			new VariantResolver(new Variant128(0.0m), typeof(decimal)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Cos")]
+	public void Cos_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new CosResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Cos")]
+	public void Cos_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new CosResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/DegToRadResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/DegToRadResolverTests.cs
@@ -1,0 +1,177 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class DegToRadResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "DegToRad")]
+	public void DegToRad_resolver_float_value_type_is_float()
+	{
+		var resolver = new DegToRadResolver(
+			new VariantResolver(new Variant128(90.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "DegToRad")]
+	public void DegToRad_resolver_double_value_type_is_double()
+	{
+		var resolver = new DegToRadResolver(
+			new VariantResolver(new Variant128(90.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "DegToRad")]
+	public void DegToRad_resolver_int_promotes_to_double()
+	{
+		var resolver = new DegToRadResolver(
+			new VariantResolver(new Variant128(90), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "DegToRad")]
+	public void DegToRad_resolver_zero_returns_zero()
+	{
+		var resolver = new DegToRadResolver(
+			new VariantResolver(new Variant128(0.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(0.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "DegToRad")]
+	public void DegToRad_resolver_90_degrees_returns_pi_over_2()
+	{
+		var resolver = new DegToRadResolver(
+			new VariantResolver(new Variant128(90.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(Math.PI / 2.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "DegToRad")]
+	public void DegToRad_resolver_180_degrees_returns_pi()
+	{
+		var resolver = new DegToRadResolver(
+			new VariantResolver(new Variant128(180.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(Math.PI, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "DegToRad")]
+	public void DegToRad_resolver_360_degrees_returns_two_pi()
+	{
+		var resolver = new DegToRadResolver(
+			new VariantResolver(new Variant128(360.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(2.0 * Math.PI, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "DegToRad")]
+	public void DegToRad_resolver_45_degrees()
+	{
+		var resolver = new DegToRadResolver(
+			new VariantResolver(new Variant128(45.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(Math.PI / 4.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "DegToRad")]
+	public void DegToRad_resolver_negative_degrees()
+	{
+		var resolver = new DegToRadResolver(
+			new VariantResolver(new Variant128(-90.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(-Math.PI / 2.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "DegToRad")]
+	public void DegToRad_resolver_float_90_degrees()
+	{
+		var resolver = new DegToRadResolver(
+			new VariantResolver(new Variant128(90.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().BeApproximately(MathF.PI / 2.0f, 0.001f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "DegToRad")]
+	public void DegToRad_resolver_supports_nesting()
+	{
+		// DegToRad(90 + 90) = DegToRad(180) = π
+		var inner = new AddResolver(
+			new VariantResolver(new Variant128(90.0), typeof(double)),
+			new VariantResolver(new Variant128(90.0), typeof(double)));
+
+		var resolver = new DegToRadResolver(inner);
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(Math.PI, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "DegToRad")]
+	public void DegToRad_resolver_throws_for_decimal_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new DegToRadResolver(
+			new VariantResolver(new Variant128(90.0m), typeof(decimal)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "DegToRad")]
+	public void DegToRad_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new DegToRadResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "DegToRad")]
+	public void DegToRad_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new DegToRadResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/DivideResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/DivideResolverTests.cs
@@ -1,0 +1,257 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class DivideResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Divide")]
+	public void Divide_resolver_int_over_int_value_type_is_int()
+	{
+		var resolver = new DivideResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(2), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(int));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Divide")]
+	public void Divide_resolver_int_over_float_promotes_to_float()
+	{
+		var resolver = new DivideResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(3.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Divide")]
+	public void Divide_resolver_vector3_over_vector3_value_type_is_vector3()
+	{
+		var resolver = new DivideResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)),
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+
+		resolver.ValueType.Should().Be(typeof(Vector3));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Divide")]
+	public void Divide_resolver_divides_two_ints()
+	{
+		var resolver = new DivideResolver(
+			new VariantResolver(new Variant128(20), typeof(int)),
+			new VariantResolver(new Variant128(4), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(5);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Divide")]
+	public void Divide_resolver_integer_division_truncates()
+	{
+		var resolver = new DivideResolver(
+			new VariantResolver(new Variant128(7), typeof(int)),
+			new VariantResolver(new Variant128(2), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(3);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Divide")]
+	public void Divide_resolver_divides_two_doubles()
+	{
+		var resolver = new DivideResolver(
+			new VariantResolver(new Variant128(10.0), typeof(double)),
+			new VariantResolver(new Variant128(4.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(2.5);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Divide")]
+	public void Divide_resolver_divides_two_floats()
+	{
+		var resolver = new DivideResolver(
+			new VariantResolver(new Variant128(9.0f), typeof(float)),
+			new VariantResolver(new Variant128(3.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(3.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Divide")]
+	public void Divide_resolver_divides_two_longs()
+	{
+		var resolver = new DivideResolver(
+			new VariantResolver(new Variant128(1000L), typeof(long)),
+			new VariantResolver(new Variant128(250L), typeof(long)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsLong().Should().Be(4L);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Divide")]
+	public void Divide_resolver_divides_two_decimals()
+	{
+		var resolver = new DivideResolver(
+			new VariantResolver(new Variant128(10.0m), typeof(decimal)),
+			new VariantResolver(new Variant128(4.0m), typeof(decimal)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDecimal().Should().Be(2.5m);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Divide")]
+	public void Divide_resolver_divides_int_and_double()
+	{
+		var resolver = new DivideResolver(
+			new VariantResolver(new Variant128(7), typeof(int)),
+			new VariantResolver(new Variant128(2.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(3.5);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Divide")]
+	public void Divide_resolver_by_one_returns_same_value()
+	{
+		var resolver = new DivideResolver(
+			new VariantResolver(new Variant128(42), typeof(int)),
+			new VariantResolver(new Variant128(1), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(42);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Divide")]
+	public void Divide_resolver_negative_dividend()
+	{
+		var resolver = new DivideResolver(
+			new VariantResolver(new Variant128(-15), typeof(int)),
+			new VariantResolver(new Variant128(3), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(-5);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Divide")]
+	public void Divide_resolver_divides_two_vector2_componentwise()
+	{
+		var resolver = new DivideResolver(
+			new VariantResolver(new Variant128(new Vector2(10, 20)), typeof(Vector2)),
+			new VariantResolver(new Variant128(new Vector2(2, 5)), typeof(Vector2)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector2().Should().Be(new Vector2(5, 4));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Divide")]
+	public void Divide_resolver_divides_two_vector3_componentwise()
+	{
+		var resolver = new DivideResolver(
+			new VariantResolver(new Variant128(new Vector3(12, 20, 30)), typeof(Vector3)),
+			new VariantResolver(new Variant128(new Vector3(3, 4, 5)), typeof(Vector3)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector3().Should().Be(new Vector3(4, 5, 6));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Divide")]
+	public void Divide_resolver_divides_two_vector4_componentwise()
+	{
+		var resolver = new DivideResolver(
+			new VariantResolver(new Variant128(new Vector4(8, 12, 16, 20)), typeof(Vector4)),
+			new VariantResolver(new Variant128(new Vector4(2, 3, 4, 5)), typeof(Vector4)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector4().Should().Be(new Vector4(4, 4, 4, 4));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Divide")]
+	public void Divide_resolver_supports_nesting()
+	{
+		// (100 / 5) / 2 = 10
+		var inner = new DivideResolver(
+			new VariantResolver(new Variant128(100), typeof(int)),
+			new VariantResolver(new Variant128(5), typeof(int)));
+
+		var outer = new DivideResolver(
+			inner,
+			new VariantResolver(new Variant128(2), typeof(int)));
+
+		var context = new GraphContext();
+
+		outer.Resolve(context).AsInt().Should().Be(10);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Divide")]
+	public void Divide_resolver_throws_for_quaternion_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new DivideResolver(
+			new VariantResolver(new Variant128(Quaternion.Identity), typeof(Quaternion)),
+			new VariantResolver(new Variant128(Quaternion.Identity), typeof(Quaternion)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Divide")]
+	public void Divide_resolver_throws_for_bool_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new DivideResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)),
+			new VariantResolver(new Variant128(false), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Divide")]
+	public void Divide_resolver_throws_for_mismatched_vector_types()
+	{
+#pragma warning disable CA1806
+		Action act = () => new DivideResolver(
+			new VariantResolver(new Variant128(Vector2.One), typeof(Vector2)),
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/EResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/EResolverTests.cs
@@ -1,0 +1,104 @@
+// Copyright © Gamesmiths Guild.
+
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class EResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "E")]
+	public void E_resolver_default_value_type_is_double()
+	{
+		var resolver = new EResolver();
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "E")]
+	public void E_resolver_explicit_double_value_type_is_double()
+	{
+		var resolver = new EResolver(typeof(double));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "E")]
+	public void E_resolver_explicit_float_value_type_is_float()
+	{
+		var resolver = new EResolver(typeof(float));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "E")]
+	public void E_resolver_double_returns_math_e()
+	{
+		var resolver = new EResolver();
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(Math.E);
+	}
+
+	[Fact]
+	[Trait("Resolver", "E")]
+	public void E_resolver_float_returns_mathf_e()
+	{
+		var resolver = new EResolver(typeof(float));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(MathF.E);
+	}
+
+	[Fact]
+	[Trait("Resolver", "E")]
+	public void E_resolver_value_is_approximately_2_71828()
+	{
+		var resolver = new EResolver();
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(2.71828, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "E")]
+	public void E_resolver_throws_for_int_type()
+	{
+#pragma warning disable CA1806
+		Action act = () => new EResolver(typeof(int));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "E")]
+	public void E_resolver_throws_for_decimal_type()
+	{
+#pragma warning disable CA1806
+		Action act = () => new EResolver(typeof(decimal));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "E")]
+	public void E_resolver_usable_in_composition()
+	{
+		// Log(e) = 1
+		var resolver = new LogResolver(new EResolver());
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(1.0, 0.0001);
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/ExpResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/ExpResolverTests.cs
@@ -1,0 +1,156 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class ExpResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Exp")]
+	public void Exp_resolver_float_value_type_is_float()
+	{
+		var resolver = new ExpResolver(
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Exp")]
+	public void Exp_resolver_double_value_type_is_double()
+	{
+		var resolver = new ExpResolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Exp")]
+	public void Exp_resolver_int_promotes_to_double()
+	{
+		var resolver = new ExpResolver(
+			new VariantResolver(new Variant128(1), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Exp")]
+	public void Exp_resolver_zero_returns_one()
+	{
+		// e^0 = 1
+		var resolver = new ExpResolver(
+			new VariantResolver(new Variant128(0.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(1.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Exp")]
+	public void Exp_resolver_one_returns_e()
+	{
+		// e^1 = e ≈ 2.71828
+		var resolver = new ExpResolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(Math.E, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Exp")]
+	public void Exp_resolver_two_returns_e_squared()
+	{
+		// e^2 ≈ 7.389
+		var resolver = new ExpResolver(
+			new VariantResolver(new Variant128(2.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(7.389, 0.01);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Exp")]
+	public void Exp_resolver_negative_returns_reciprocal()
+	{
+		// e^-1 = 1/e ≈ 0.3679
+		var resolver = new ExpResolver(
+			new VariantResolver(new Variant128(-1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(1.0 / Math.E, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Exp")]
+	public void Exp_resolver_float_computation()
+	{
+		var resolver = new ExpResolver(
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().BeApproximately(MathF.E, 0.001f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Exp")]
+	public void Exp_resolver_supports_nesting()
+	{
+		// Exp(Exp(0)) = Exp(1) = e
+		var inner = new ExpResolver(
+			new VariantResolver(new Variant128(0.0), typeof(double)));
+
+		var outer = new ExpResolver(inner);
+
+		var context = new GraphContext();
+
+		outer.Resolve(context).AsDouble().Should().BeApproximately(Math.E, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Exp")]
+	public void Exp_resolver_throws_for_decimal_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ExpResolver(
+			new VariantResolver(new Variant128(1.0m), typeof(decimal)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Exp")]
+	public void Exp_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ExpResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Exp")]
+	public void Exp_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ExpResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/FloorResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/FloorResolverTests.cs
@@ -1,0 +1,177 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class FloorResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Floor")]
+	public void Floor_resolver_float_value_type_is_float()
+	{
+		var resolver = new FloorResolver(
+			new VariantResolver(new Variant128(2.7f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Floor")]
+	public void Floor_resolver_double_value_type_is_double()
+	{
+		var resolver = new FloorResolver(
+			new VariantResolver(new Variant128(2.7), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Floor")]
+	public void Floor_resolver_decimal_value_type_is_decimal()
+	{
+		var resolver = new FloorResolver(
+			new VariantResolver(new Variant128(2.7m), typeof(decimal)));
+
+		resolver.ValueType.Should().Be(typeof(decimal));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Floor")]
+	public void Floor_resolver_positive_float()
+	{
+		var resolver = new FloorResolver(
+			new VariantResolver(new Variant128(2.7f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(2.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Floor")]
+	public void Floor_resolver_negative_float()
+	{
+		var resolver = new FloorResolver(
+			new VariantResolver(new Variant128(-2.3f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(-3.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Floor")]
+	public void Floor_resolver_positive_double()
+	{
+		var resolver = new FloorResolver(
+			new VariantResolver(new Variant128(3.99), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(3.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Floor")]
+	public void Floor_resolver_negative_double()
+	{
+		var resolver = new FloorResolver(
+			new VariantResolver(new Variant128(-1.1), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(-2.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Floor")]
+	public void Floor_resolver_positive_decimal()
+	{
+		var resolver = new FloorResolver(
+			new VariantResolver(new Variant128(5.9m), typeof(decimal)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDecimal().Should().Be(5.0m);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Floor")]
+	public void Floor_resolver_negative_decimal()
+	{
+		var resolver = new FloorResolver(
+			new VariantResolver(new Variant128(-5.1m), typeof(decimal)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDecimal().Should().Be(-6.0m);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Floor")]
+	public void Floor_resolver_whole_number_returns_same()
+	{
+		var resolver = new FloorResolver(
+			new VariantResolver(new Variant128(5.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(5.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Floor")]
+	public void Floor_resolver_supports_nesting()
+	{
+		// Floor(2.7 + 1.1) = Floor(3.8) = 3.0
+		var sum = new AddResolver(
+			new VariantResolver(new Variant128(2.7), typeof(double)),
+			new VariantResolver(new Variant128(1.1), typeof(double)));
+
+		var resolver = new FloorResolver(sum);
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(3.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Floor")]
+	public void Floor_resolver_throws_for_int_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new FloorResolver(
+			new VariantResolver(new Variant128(5), typeof(int)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Floor")]
+	public void Floor_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new FloorResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Floor")]
+	public void Floor_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new FloorResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/LerpResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/LerpResolverTests.cs
@@ -1,0 +1,474 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class LerpResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_float_operands_value_type_is_float()
+	{
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(0.0f), typeof(float)),
+			new VariantResolver(new Variant128(10.0f), typeof(float)),
+			new VariantResolver(new Variant128(0.5f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_double_operands_value_type_is_double()
+	{
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(0.0), typeof(double)),
+			new VariantResolver(new Variant128(10.0), typeof(double)),
+			new VariantResolver(new Variant128(0.5), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_mixed_float_and_double_promotes_to_double()
+	{
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(0.0f), typeof(float)),
+			new VariantResolver(new Variant128(10.0), typeof(double)),
+			new VariantResolver(new Variant128(0.5f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_vector2_value_type_is_vector2()
+	{
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(Vector2.Zero), typeof(Vector2)),
+			new VariantResolver(new Variant128(Vector2.One), typeof(Vector2)),
+			new VariantResolver(new Variant128(0.5f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(Vector2));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_vector3_value_type_is_vector3()
+	{
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(Vector3.Zero), typeof(Vector3)),
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)),
+			new VariantResolver(new Variant128(0.5f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(Vector3));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_vector4_value_type_is_vector4()
+	{
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(Vector4.Zero), typeof(Vector4)),
+			new VariantResolver(new Variant128(Vector4.One), typeof(Vector4)),
+			new VariantResolver(new Variant128(0.5f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(Vector4));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_quaternion_value_type_is_quaternion()
+	{
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(Quaternion.Identity), typeof(Quaternion)),
+			new VariantResolver(new Variant128(Quaternion.Identity), typeof(Quaternion)),
+			new VariantResolver(new Variant128(0.5f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(Quaternion));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_at_zero_returns_start()
+	{
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(10.0f), typeof(float)),
+			new VariantResolver(new Variant128(30.0f), typeof(float)),
+			new VariantResolver(new Variant128(0.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(10.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_at_one_returns_end()
+	{
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(10.0f), typeof(float)),
+			new VariantResolver(new Variant128(30.0f), typeof(float)),
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(30.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_at_half_returns_midpoint()
+	{
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(10.0f), typeof(float)),
+			new VariantResolver(new Variant128(30.0f), typeof(float)),
+			new VariantResolver(new Variant128(0.5f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(20.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_at_quarter()
+	{
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(0.0), typeof(double)),
+			new VariantResolver(new Variant128(100.0), typeof(double)),
+			new VariantResolver(new Variant128(0.25), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(25.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_double_interpolation()
+	{
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(10.0), typeof(double)),
+			new VariantResolver(new Variant128(20.0), typeof(double)),
+			new VariantResolver(new Variant128(0.3), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(13.0, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_negative_range()
+	{
+		// Lerp(-10, 10, 0.5) = -10 + (10 - (-10)) * 0.5 = -10 + 10 = 0
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(-10.0f), typeof(float)),
+			new VariantResolver(new Variant128(10.0f), typeof(float)),
+			new VariantResolver(new Variant128(0.5f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(0.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_beyond_one_extrapolates()
+	{
+		// Lerp(0, 10, 1.5) = 0 + (10 - 0) * 1.5 = 15
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(0.0f), typeof(float)),
+			new VariantResolver(new Variant128(10.0f), typeof(float)),
+			new VariantResolver(new Variant128(1.5f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(15.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_vector2_at_half()
+	{
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(new Vector2(0, 0)), typeof(Vector2)),
+			new VariantResolver(new Variant128(new Vector2(10, 20)), typeof(Vector2)),
+			new VariantResolver(new Variant128(0.5f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector2().Should().Be(new Vector2(5, 10));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_vector2_at_zero_returns_start()
+	{
+		var a = new Vector2(1, 2);
+
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(a), typeof(Vector2)),
+			new VariantResolver(new Variant128(new Vector2(10, 20)), typeof(Vector2)),
+			new VariantResolver(new Variant128(0.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector2().Should().Be(a);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_vector2_at_one_returns_end()
+	{
+		var b = new Vector2(10, 20);
+
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(new Vector2(1, 2)), typeof(Vector2)),
+			new VariantResolver(new Variant128(b), typeof(Vector2)),
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector2().Should().Be(b);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_vector3_at_half()
+	{
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(new Vector3(0, 0, 0)), typeof(Vector3)),
+			new VariantResolver(new Variant128(new Vector3(10, 20, 30)), typeof(Vector3)),
+			new VariantResolver(new Variant128(0.5f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector3().Should().Be(new Vector3(5, 10, 15));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_vector3_at_zero_returns_start()
+	{
+		var a = new Vector3(1, 2, 3);
+
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(a), typeof(Vector3)),
+			new VariantResolver(new Variant128(new Vector3(10, 20, 30)), typeof(Vector3)),
+			new VariantResolver(new Variant128(0.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector3().Should().Be(a);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_vector3_at_one_returns_end()
+	{
+		var b = new Vector3(10, 20, 30);
+
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(new Vector3(1, 2, 3)), typeof(Vector3)),
+			new VariantResolver(new Variant128(b), typeof(Vector3)),
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector3().Should().Be(b);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_vector4_at_half()
+	{
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(new Vector4(0, 0, 0, 0)), typeof(Vector4)),
+			new VariantResolver(new Variant128(new Vector4(10, 20, 30, 40)), typeof(Vector4)),
+			new VariantResolver(new Variant128(0.5f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector4().Should().Be(new Vector4(5, 10, 15, 20));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_quaternion_at_half()
+	{
+		Quaternion a = Quaternion.Identity;
+		var b = Quaternion.CreateFromAxisAngle(Vector3.UnitY, MathF.PI);
+
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(a), typeof(Quaternion)),
+			new VariantResolver(new Variant128(b), typeof(Quaternion)),
+			new VariantResolver(new Variant128(0.5f), typeof(float)));
+
+		var context = new GraphContext();
+
+		var expected = Quaternion.Lerp(a, b, 0.5f);
+		Quaternion result = resolver.Resolve(context).AsQuaternion();
+
+		result.X.Should().BeApproximately(expected.X, 0.001f);
+		result.Y.Should().BeApproximately(expected.Y, 0.001f);
+		result.Z.Should().BeApproximately(expected.Z, 0.001f);
+		result.W.Should().BeApproximately(expected.W, 0.001f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_quaternion_at_zero_returns_start()
+	{
+		Quaternion a = Quaternion.Identity;
+		var b = Quaternion.CreateFromAxisAngle(Vector3.UnitY, MathF.PI / 2);
+
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(a), typeof(Quaternion)),
+			new VariantResolver(new Variant128(b), typeof(Quaternion)),
+			new VariantResolver(new Variant128(0.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		var expected = Quaternion.Lerp(a, b, 0.0f);
+		Quaternion result = resolver.Resolve(context).AsQuaternion();
+
+		result.X.Should().BeApproximately(expected.X, 0.001f);
+		result.Y.Should().BeApproximately(expected.Y, 0.001f);
+		result.Z.Should().BeApproximately(expected.Z, 0.001f);
+		result.W.Should().BeApproximately(expected.W, 0.001f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_quaternion_at_one_returns_end()
+	{
+		Quaternion a = Quaternion.Identity;
+		var b = Quaternion.CreateFromAxisAngle(Vector3.UnitY, MathF.PI / 2);
+
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(a), typeof(Quaternion)),
+			new VariantResolver(new Variant128(b), typeof(Quaternion)),
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		var expected = Quaternion.Lerp(a, b, 1.0f);
+		Quaternion result = resolver.Resolve(context).AsQuaternion();
+
+		result.X.Should().BeApproximately(expected.X, 0.001f);
+		result.Y.Should().BeApproximately(expected.Y, 0.001f);
+		result.Z.Should().BeApproximately(expected.Z, 0.001f);
+		result.W.Should().BeApproximately(expected.W, 0.001f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_supports_nesting()
+	{
+		// Lerp(Lerp(0, 10, 0.5), 20, 0.5) = Lerp(5, 20, 0.5) = 12.5
+		var inner = new LerpResolver(
+			new VariantResolver(new Variant128(0.0f), typeof(float)),
+			new VariantResolver(new Variant128(10.0f), typeof(float)),
+			new VariantResolver(new Variant128(0.5f), typeof(float)));
+
+		var outer = new LerpResolver(
+			inner,
+			new VariantResolver(new Variant128(20.0f), typeof(float)),
+			new VariantResolver(new Variant128(0.5f), typeof(float)));
+
+		var context = new GraphContext();
+
+		outer.Resolve(context).AsFloat().Should().Be(12.5f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_throws_for_int_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new LerpResolver(
+			new VariantResolver(new Variant128(0), typeof(int)),
+			new VariantResolver(new Variant128(10.0f), typeof(float)),
+			new VariantResolver(new Variant128(0.5f), typeof(float)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_throws_for_decimal_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new LerpResolver(
+			new VariantResolver(new Variant128(0.0m), typeof(decimal)),
+			new VariantResolver(new Variant128(10.0m), typeof(decimal)),
+			new VariantResolver(new Variant128(0.5m), typeof(decimal)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new LerpResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)),
+			new VariantResolver(new Variant128(false), typeof(bool)),
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_throws_for_mismatched_vector_types()
+	{
+#pragma warning disable CA1806
+		Action act = () => new LerpResolver(
+			new VariantResolver(new Variant128(Vector2.One), typeof(Vector2)),
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)),
+			new VariantResolver(new Variant128(0.5f), typeof(float)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_throws_for_vector_with_double_t()
+	{
+#pragma warning disable CA1806
+		Action act = () => new LerpResolver(
+			new VariantResolver(new Variant128(Vector3.Zero), typeof(Vector3)),
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)),
+			new VariantResolver(new Variant128(0.5), typeof(double)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Lerp")]
+	public void Lerp_resolver_throws_for_vector_with_int_t()
+	{
+#pragma warning disable CA1806
+		Action act = () => new LerpResolver(
+			new VariantResolver(new Variant128(Vector3.Zero), typeof(Vector3)),
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)),
+			new VariantResolver(new Variant128(0), typeof(int)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/Log10ResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/Log10ResolverTests.cs
@@ -1,0 +1,141 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class Log10ResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Log10")]
+	public void Log10_resolver_float_value_type_is_float()
+	{
+		var resolver = new Log10Resolver(
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log10")]
+	public void Log10_resolver_double_value_type_is_double()
+	{
+		var resolver = new Log10Resolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log10")]
+	public void Log10_resolver_int_promotes_to_double()
+	{
+		var resolver = new Log10Resolver(
+			new VariantResolver(new Variant128(1), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log10")]
+	public void Log10_resolver_one_returns_zero()
+	{
+		// Log10(1) = 0
+		var resolver = new Log10Resolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(0.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log10")]
+	public void Log10_resolver_ten_returns_one()
+	{
+		// Log10(10) = 1
+		var resolver = new Log10Resolver(
+			new VariantResolver(new Variant128(10.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(1.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log10")]
+	public void Log10_resolver_hundred_returns_two()
+	{
+		// Log10(100) = 2
+		var resolver = new Log10Resolver(
+			new VariantResolver(new Variant128(100.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(2.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log10")]
+	public void Log10_resolver_thousand_returns_three()
+	{
+		// Log10(1000) = 3
+		var resolver = new Log10Resolver(
+			new VariantResolver(new Variant128(1000.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(3.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log10")]
+	public void Log10_resolver_float_computation()
+	{
+		var resolver = new Log10Resolver(
+			new VariantResolver(new Variant128(100.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().BeApproximately(2.0f, 0.001f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log10")]
+	public void Log10_resolver_throws_for_decimal_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new Log10Resolver(
+			new VariantResolver(new Variant128(1.0m), typeof(decimal)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log10")]
+	public void Log10_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new Log10Resolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log10")]
+	public void Log10_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new Log10Resolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/Log2ResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/Log2ResolverTests.cs
@@ -1,0 +1,141 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class Log2ResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Log2")]
+	public void Log2_resolver_float_value_type_is_float()
+	{
+		var resolver = new Log2Resolver(
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log2")]
+	public void Log2_resolver_double_value_type_is_double()
+	{
+		var resolver = new Log2Resolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log2")]
+	public void Log2_resolver_int_promotes_to_double()
+	{
+		var resolver = new Log2Resolver(
+			new VariantResolver(new Variant128(1), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log2")]
+	public void Log2_resolver_one_returns_zero()
+	{
+		// Log2(1) = 0
+		var resolver = new Log2Resolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(0.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log2")]
+	public void Log2_resolver_two_returns_one()
+	{
+		// Log2(2) = 1
+		var resolver = new Log2Resolver(
+			new VariantResolver(new Variant128(2.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(1.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log2")]
+	public void Log2_resolver_eight_returns_three()
+	{
+		// Log2(8) = 3
+		var resolver = new Log2Resolver(
+			new VariantResolver(new Variant128(8.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(3.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log2")]
+	public void Log2_resolver_1024_returns_10()
+	{
+		// Log2(1024) = 10
+		var resolver = new Log2Resolver(
+			new VariantResolver(new Variant128(1024.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(10.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log2")]
+	public void Log2_resolver_float_computation()
+	{
+		var resolver = new Log2Resolver(
+			new VariantResolver(new Variant128(4.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().BeApproximately(2.0f, 0.001f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log2")]
+	public void Log2_resolver_throws_for_decimal_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new Log2Resolver(
+			new VariantResolver(new Variant128(1.0m), typeof(decimal)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log2")]
+	public void Log2_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new Log2Resolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log2")]
+	public void Log2_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new Log2Resolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/LogResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/LogResolverTests.cs
@@ -1,0 +1,144 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class LogResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Log")]
+	public void Log_resolver_float_value_type_is_float()
+	{
+		var resolver = new LogResolver(
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log")]
+	public void Log_resolver_double_value_type_is_double()
+	{
+		var resolver = new LogResolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log")]
+	public void Log_resolver_int_promotes_to_double()
+	{
+		var resolver = new LogResolver(
+			new VariantResolver(new Variant128(1), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log")]
+	public void Log_resolver_one_returns_zero()
+	{
+		// Log(1) = 0
+		var resolver = new LogResolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(0.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log")]
+	public void Log_resolver_e_returns_one()
+	{
+		// Log(e) = 1
+		var resolver = new LogResolver(
+			new VariantResolver(new Variant128(Math.E), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(1.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log")]
+	public void Log_resolver_e_squared()
+	{
+		// Log(e^2) = 2
+		var resolver = new LogResolver(
+			new VariantResolver(new Variant128(Math.E * Math.E), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(2.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log")]
+	public void Log_resolver_float_computation()
+	{
+		// Log(e) ≈ 1
+		var resolver = new LogResolver(
+			new VariantResolver(new Variant128(MathF.E), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().BeApproximately(1.0f, 0.001f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log")]
+	public void Log_resolver_supports_nesting()
+	{
+		// Log(Log(e^e)) = Log(e) = 1 — Wait: Log(e^e) = e, Log(e) = 1
+		var inner = new LogResolver(
+			new VariantResolver(new Variant128(Math.Pow(Math.E, Math.E)), typeof(double)));
+
+		var outer = new LogResolver(inner);
+
+		var context = new GraphContext();
+
+		outer.Resolve(context).AsDouble().Should().BeApproximately(1.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log")]
+	public void Log_resolver_throws_for_decimal_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new LogResolver(
+			new VariantResolver(new Variant128(1.0m), typeof(decimal)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log")]
+	public void Log_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new LogResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Log")]
+	public void Log_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new LogResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/MathResolversTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/MathResolversTests.cs
@@ -1,0 +1,456 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class MathResolversTests
+{
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Add_then_multiply_follows_explicit_grouping()
+	{
+		// (10 + 5) * 3 = 45
+		var resolver = new MultiplyResolver(
+			new AddResolver(
+				new VariantResolver(new Variant128(10), typeof(int)),
+				new VariantResolver(new Variant128(5), typeof(int))),
+			new VariantResolver(new Variant128(3), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(45);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Multiply_then_add_follows_explicit_grouping()
+	{
+		// 10 + (5 * 3) = 25
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new MultiplyResolver(
+				new VariantResolver(new Variant128(5), typeof(int)),
+				new VariantResolver(new Variant128(3), typeof(int))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(25);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Four_operations_chained()
+	{
+		// ((10 + 2) * 3 - 6) / 3 = (12 * 3 - 6) / 3 = (36 - 6) / 3 = 30 / 3 = 10
+		var addStep = new AddResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(2), typeof(int)));
+
+		var multiplyStep = new MultiplyResolver(
+			addStep,
+			new VariantResolver(new Variant128(3), typeof(int)));
+
+		var subtractStep = new SubtractResolver(
+			multiplyStep,
+			new VariantResolver(new Variant128(6), typeof(int)));
+
+		var divideStep = new DivideResolver(
+			subtractStep,
+			new VariantResolver(new Variant128(3), typeof(int)));
+
+		var context = new GraphContext();
+
+		divideStep.Resolve(context).AsInt().Should().Be(10);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Damage_formula_base_plus_bonus_times_multiplier()
+	{
+		// finalDamage = (baseDamage + bonusDamage) * critMultiplier
+		// (25 + 10) * 2 = 70
+		var resolver = new MultiplyResolver(
+			new AddResolver(
+				new VariantResolver(new Variant128(25), typeof(int)),
+				new VariantResolver(new Variant128(10), typeof(int))),
+			new VariantResolver(new Variant128(2), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(70);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Effective_damage_after_armor_reduction()
+	{
+		// effectiveDamage = rawDamage - (rawDamage * armorReduction)
+		// 100 - (100 * 0.25) = 100 - 25 = 75.0
+		var rawDamage = new VariantResolver(new Variant128(100.0), typeof(double));
+		var armorReduction = new VariantResolver(new Variant128(0.25), typeof(double));
+
+		var resolver = new SubtractResolver(
+			rawDamage,
+			new MultiplyResolver(rawDamage, armorReduction));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(75.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Health_percentage_formula()
+	{
+		// healthPercent = (currentHealth / maxHealth) * 100
+		// (75.0 / 200.0) * 100.0 = 37.5
+		var resolver = new MultiplyResolver(
+			new DivideResolver(
+				new VariantResolver(new Variant128(75.0), typeof(double)),
+				new VariantResolver(new Variant128(200.0), typeof(double))),
+			new VariantResolver(new Variant128(100.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(37.5);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Cooldown_reduction_formula()
+	{
+		// effectiveCooldown = baseCooldown * (1.0 - cooldownReduction)
+		// 10.0 * (1.0 - 0.3) = 10.0 * 0.7 = 7.0
+		var resolver = new MultiplyResolver(
+			new VariantResolver(new Variant128(10.0), typeof(double)),
+			new SubtractResolver(
+				new VariantResolver(new Variant128(1.0), typeof(double)),
+				new VariantResolver(new Variant128(0.3), typeof(double))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(7.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Linear_interpolation_formula()
+	{
+		// lerp(a, b, t) = a + (b - a) * t
+		// lerp(10, 30, 0.5) = 10 + (30 - 10) * 0.5 = 10 + 10 = 20
+		var a = new VariantResolver(new Variant128(10.0), typeof(double));
+		var b = new VariantResolver(new Variant128(30.0), typeof(double));
+		var t = new VariantResolver(new Variant128(0.5), typeof(double));
+
+		var resolver = new AddResolver(
+			a,
+			new MultiplyResolver(
+				new SubtractResolver(b, a),
+				t));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(20.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Linear_interpolation_at_boundaries()
+	{
+		// lerp(10, 30, 0.0) = 10, lerp(10, 30, 1.0) = 30
+		var a = new VariantResolver(new Variant128(10.0), typeof(double));
+		var b = new VariantResolver(new Variant128(30.0), typeof(double));
+
+		var t0 = new VariantResolver(new Variant128(0.0), typeof(double));
+		var t1 = new VariantResolver(new Variant128(1.0), typeof(double));
+
+		var lerpAtZero = new AddResolver(
+			a,
+			new MultiplyResolver(new SubtractResolver(b, a), t0));
+
+		var lerpAtOne = new AddResolver(
+			a,
+			new MultiplyResolver(new SubtractResolver(b, a), t1));
+
+		var context = new GraphContext();
+
+		lerpAtZero.Resolve(context).AsDouble().Should().Be(10.0);
+		lerpAtOne.Resolve(context).AsDouble().Should().Be(30.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Absolute_distance_between_two_values()
+	{
+		// distance = Abs(a - b)
+		// Abs(10 - 25) = Abs(-15) = 15
+		var resolver = new AbsResolver(
+			new SubtractResolver(
+				new VariantResolver(new Variant128(10), typeof(int)),
+				new VariantResolver(new Variant128(25), typeof(int))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(15);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Negate_used_to_subtract_via_addition()
+	{
+		// a + (-b) equivalent to a - b
+		// 20 + (-8) = 12
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(20), typeof(int)),
+			new NegateResolver(
+				new VariantResolver(new Variant128(8), typeof(int))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(12);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Cycle_index_with_offset()
+	{
+		// cycleIndex = (frameCount + offset) % cycleLength
+		// (17 + 3) % 6 = 20 % 6 = 2
+		var resolver = new ModuloResolver(
+			new AddResolver(
+				new VariantResolver(new Variant128(17), typeof(int)),
+				new VariantResolver(new Variant128(3), typeof(int))),
+			new VariantResolver(new Variant128(6), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(2);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Even_odd_check_with_modulo_and_comparison()
+	{
+		// isEven = (value % 2) == 0
+		// 42 % 2 = 0, so isEven = true
+		var modulo = new ModuloResolver(
+			new VariantResolver(new Variant128(42), typeof(int)),
+			new VariantResolver(new Variant128(2), typeof(int)));
+
+		var resolver = new ComparisonResolver(
+			modulo,
+			ComparisonOperation.Equal,
+			new VariantResolver(new Variant128(0), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsBool().Should().BeTrue();
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Mixed_int_and_float_arithmetic()
+	{
+		// (int 10 + float 2.5) * float 3.0 = float 12.5 * 3.0 = 37.5
+		var resolver = new MultiplyResolver(
+			new AddResolver(
+				new VariantResolver(new Variant128(10), typeof(int)),
+				new VariantResolver(new Variant128(2.5f), typeof(float))),
+			new VariantResolver(new Variant128(3.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(37.5f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Vector_midpoint_formula()
+	{
+		// midpoint = (a + b) / (2, 2, 2)
+		// ((1,2,3) + (5,8,9)) / (2,2,2) = (6,10,12) / (2,2,2) = (3,5,6)
+		var resolver = new DivideResolver(
+			new AddResolver(
+				new VariantResolver(new Variant128(new Vector3(1, 2, 3)), typeof(Vector3)),
+				new VariantResolver(new Variant128(new Vector3(5, 8, 9)), typeof(Vector3))),
+			new VariantResolver(new Variant128(new Vector3(2, 2, 2)), typeof(Vector3)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector3().Should().Be(new Vector3(3, 5, 6));
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Vector_reflect_direction()
+	{
+		// Simplified reflect: reflected = -velocity + (2,2) * bounce
+		// -(3,4) + (2,2) * (1,1) = (-3,-4) + (2,2) = (-1,-2)
+		var resolver = new AddResolver(
+			new NegateResolver(
+				new VariantResolver(new Variant128(new Vector2(3, 4)), typeof(Vector2))),
+			new MultiplyResolver(
+				new VariantResolver(new Variant128(new Vector2(2, 2)), typeof(Vector2)),
+				new VariantResolver(new Variant128(new Vector2(1, 1)), typeof(Vector2))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector2().Should().Be(new Vector2(-1, -2));
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Compound_formula_with_graph_variables()
+	{
+		// effectiveValue = (base + bonus) * multiplier - penalty
+		// (50 + 20) * 2 - 15 = 140 - 15 = 125
+		var graph = new Graph();
+		graph.VariableDefinitions.DefineVariable("base", 50);
+		graph.VariableDefinitions.DefineVariable("bonus", 20);
+		graph.VariableDefinitions.DefineVariable("multiplier", 2);
+		graph.VariableDefinitions.DefineVariable("penalty", 15);
+
+		var context = new GraphContext();
+		context.GraphVariables.InitializeFrom(graph.VariableDefinitions);
+
+		var resolver = new SubtractResolver(
+			new MultiplyResolver(
+				new AddResolver(
+					new VariableResolver("base", typeof(int)),
+					new VariableResolver("bonus", typeof(int))),
+				new VariableResolver("multiplier", typeof(int))),
+			new VariableResolver("penalty", typeof(int)));
+
+		resolver.Resolve(context).AsInt().Should().Be(125);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Compound_formula_reflects_variable_changes()
+	{
+		// result = (a + b) * c
+		var graph = new Graph();
+		graph.VariableDefinitions.DefineVariable("a", 5);
+		graph.VariableDefinitions.DefineVariable("b", 3);
+		graph.VariableDefinitions.DefineVariable("c", 2);
+
+		var context = new GraphContext();
+		context.GraphVariables.InitializeFrom(graph.VariableDefinitions);
+
+		var resolver = new MultiplyResolver(
+			new AddResolver(
+				new VariableResolver("a", typeof(int)),
+				new VariableResolver("b", typeof(int))),
+			new VariableResolver("c", typeof(int)));
+
+		// (5 + 3) * 2 = 16
+		resolver.Resolve(context).AsInt().Should().Be(16);
+
+		context.GraphVariables.SetVar("a", 10);
+		context.GraphVariables.SetVar("c", 3);
+
+		// (10 + 3) * 3 = 39
+		resolver.Resolve(context).AsInt().Should().Be(39);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Health_below_threshold_after_damage()
+	{
+		// isDanger = (maxHealth - damageTaken) < threshold
+		// (100 - 80) < 30 → 20 < 30 → true
+		var resolver = new ComparisonResolver(
+			new SubtractResolver(
+				new VariantResolver(new Variant128(100), typeof(int)),
+				new VariantResolver(new Variant128(80), typeof(int))),
+			ComparisonOperation.LessThan,
+			new VariantResolver(new Variant128(30), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsBool().Should().BeTrue();
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Combined_stat_exceeds_requirement()
+	{
+		// meetsRequirement = (strength + dexterity) >= requiredTotal
+		// (15 + 12) >= 25 → 27 >= 25 → true
+		var resolver = new ComparisonResolver(
+			new AddResolver(
+				new VariantResolver(new Variant128(15), typeof(int)),
+				new VariantResolver(new Variant128(12), typeof(int))),
+			ComparisonOperation.GreaterThanOrEqual,
+			new VariantResolver(new Variant128(25), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsBool().Should().BeTrue();
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Quadratic_expression()
+	{
+		// f(x) = ax² + bx + c  where a=2, b=3, c=5, x=4
+		// 2*16 + 3*4 + 5 = 32 + 12 + 5 = 49
+		var a = new VariantResolver(new Variant128(2), typeof(int));
+		var b = new VariantResolver(new Variant128(3), typeof(int));
+		var c = new VariantResolver(new Variant128(5), typeof(int));
+		var x = new VariantResolver(new Variant128(4), typeof(int));
+
+		var xSquared = new MultiplyResolver(x, x);
+		var ax2 = new MultiplyResolver(a, xSquared);
+		var bx = new MultiplyResolver(b, x);
+
+		var resolver = new AddResolver(
+			new AddResolver(ax2, bx),
+			c);
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(49);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Weighted_average_three_values()
+	{
+		// weightedAvg = (v1*w1 + v2*w2 + v3*w3) / (w1 + w2 + w3)
+		// (80*2.0 + 90*3.0 + 70*1.0) / (2.0 + 3.0 + 1.0) = (160+270+70) / 6 = 500/6 ≈ 83.333
+		var v1w1 = new MultiplyResolver(
+			new VariantResolver(new Variant128(80.0), typeof(double)),
+			new VariantResolver(new Variant128(2.0), typeof(double)));
+
+		var v2w2 = new MultiplyResolver(
+			new VariantResolver(new Variant128(90.0), typeof(double)),
+			new VariantResolver(new Variant128(3.0), typeof(double)));
+
+		var v3w3 = new MultiplyResolver(
+			new VariantResolver(new Variant128(70.0), typeof(double)),
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		var numerator = new AddResolver(
+			new AddResolver(v1w1, v2w2),
+			v3w3);
+
+		var denominator = new AddResolver(
+			new AddResolver(
+				new VariantResolver(new Variant128(2.0), typeof(double)),
+				new VariantResolver(new Variant128(3.0), typeof(double))),
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		var resolver = new DivideResolver(numerator, denominator);
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(83.333, 0.01);
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/MathResolversTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/MathResolversTests.cs
@@ -2,8 +2,10 @@
 
 using System.Numerics;
 using FluentAssertions;
+using Gamesmiths.Forge.Core;
 using Gamesmiths.Forge.Statescript;
 using Gamesmiths.Forge.Statescript.Properties;
+using Gamesmiths.Forge.Tests.Helpers;
 
 namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
 
@@ -952,5 +954,129 @@ public class MathResolversTests
 		var context = new GraphContext();
 
 		resolver.Resolve(context).AsDouble().Should().BeApproximately(3.5, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Trig_with_degrees_using_DegToRad()
+	{
+		// Sin(DegToRad(30)) = Sin(π/6) = 0.5
+		var resolver = new SinResolver(
+			new DegToRadResolver(
+				new VariantResolver(new Variant128(30.0), typeof(double))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(0.5, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void RadToDeg_after_ATan2_for_aiming_angle()
+	{
+		// angle = RadToDeg(ATan2(1, 1)) = RadToDeg(π/4) = 45°
+		var resolver = new RadToDegResolver(
+			new ATan2Resolver(
+				new VariantResolver(new Variant128(1.0), typeof(double)),
+				new VariantResolver(new Variant128(1.0), typeof(double))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(45.0, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Pi_resolver_in_circle_area_formula()
+	{
+		// area = Pi * r^2
+		// Pi * 5^2 = Pi * 25 ≈ 78.5398
+		var resolver = new MultiplyResolver(
+			new PiResolver(),
+			new PowResolver(
+				new VariantResolver(new Variant128(5.0), typeof(double)),
+				new VariantResolver(new Variant128(2.0), typeof(double))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(Math.PI * 25.0, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void E_resolver_in_natural_exponential()
+	{
+		// Pow(e, 2) = e^2 ≈ 7.389
+		var resolver = new PowResolver(
+			new EResolver(),
+			new VariantResolver(new Variant128(2.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(Math.E * Math.E, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Random_damage_range()
+	{
+		// damage = baseDamage + Random(0, bonusRange)
+		// With fixed random (nextSingle=0.5): 50 + Random(0, 20) = 50 + 10 = 60
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(50.0f), typeof(float)),
+			new RandomResolver(
+				new FixedRandom(nextSingle: 0.5f),
+				new VariantResolver(new Variant128(0.0f), typeof(float)),
+				new VariantResolver(new Variant128(20.0f), typeof(float))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(60.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Round_with_digits_for_display_value()
+	{
+		// Display damage per second with 1 decimal place
+		// Round(totalDamage / time, 1) = Round(100.0 / 3.0, 1) = Round(33.333, 1) = 33.3
+		var resolver = new RoundResolver(
+			new DivideResolver(
+				new VariantResolver(new Variant128(100.0), typeof(double)),
+				new VariantResolver(new Variant128(3.0), typeof(double))),
+			digits: 1);
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(33.3);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Round_away_from_zero_for_score_display()
+	{
+		// Round score to nearest 0.5 increment using AwayFromZero
+		// Round(7.5, AwayFromZero) = 8 (not 8 with ToEven, but here the midpoint rounds up)
+		var resolver = new RoundResolver(
+			new VariantResolver(new Variant128(7.5), typeof(double)),
+			mode: MidpointRounding.AwayFromZero);
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(8.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void DegToRad_and_RadToDeg_roundtrip()
+	{
+		// RadToDeg(DegToRad(135)) = 135
+		var resolver = new RadToDegResolver(
+			new DegToRadResolver(
+				new VariantResolver(new Variant128(135.0), typeof(double))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(135.0, 0.0001);
 	}
 }

--- a/Forge.Tests/Statescript/Resolvers/MathResolversTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/MathResolversTests.cs
@@ -453,4 +453,299 @@ public class MathResolversTests
 
 		resolver.Resolve(context).AsDouble().Should().BeApproximately(83.333, 0.01);
 	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Clamped_health_after_damage()
+	{
+		// clampedHealth = Clamp(currentHealth - damage, 0, maxHealth)
+		// Clamp(100 - 150, 0, 100) = Clamp(-50, 0, 100) = 0
+		var resolver = new ClampResolver(
+			new SubtractResolver(
+				new VariantResolver(new Variant128(100), typeof(int)),
+				new VariantResolver(new Variant128(150), typeof(int))),
+			new VariantResolver(new Variant128(0), typeof(int)),
+			new VariantResolver(new Variant128(100), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Clamped_health_after_heal()
+	{
+		// clampedHealth = Clamp(currentHealth + heal, 0, maxHealth)
+		// Clamp(80 + 50, 0, 100) = Clamp(130, 0, 100) = 100
+		var resolver = new ClampResolver(
+			new AddResolver(
+				new VariantResolver(new Variant128(80), typeof(int)),
+				new VariantResolver(new Variant128(50), typeof(int))),
+			new VariantResolver(new Variant128(0), typeof(int)),
+			new VariantResolver(new Variant128(100), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(100);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Min_max_to_clamp_stat()
+	{
+		// Clamp implemented as Max(min, Min(value, max))
+		// Max(0, Min(150, 100)) = Max(0, 100) = 100
+		var resolver = new MaxResolver(
+			new VariantResolver(new Variant128(0), typeof(int)),
+			new MinResolver(
+				new VariantResolver(new Variant128(150), typeof(int)),
+				new VariantResolver(new Variant128(100), typeof(int))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(100);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Lerp_for_smooth_transition()
+	{
+		// Smoothly transition between walk and run speed
+		// Lerp(walkSpeed, runSpeed, t) = Lerp(3.0, 8.0, 0.7) = 3 + (8 - 3) * 0.7 = 3 + 3.5 = 6.5
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(3.0f), typeof(float)),
+			new VariantResolver(new Variant128(8.0f), typeof(float)),
+			new VariantResolver(new Variant128(0.7f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().BeApproximately(6.5f, 0.001f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Clamped_lerp_for_safe_interpolation()
+	{
+		// Safe lerp: Lerp(a, b, Clamp(t, 0, 1))
+		// Lerp(0, 100, Clamp(1.5, 0, 1)) = Lerp(0, 100, 1.0) = 100
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(0.0f), typeof(float)),
+			new VariantResolver(new Variant128(100.0f), typeof(float)),
+			new ClampResolver(
+				new VariantResolver(new Variant128(1.5f), typeof(float)),
+				new VariantResolver(new Variant128(0.0f), typeof(float)),
+				new VariantResolver(new Variant128(1.0f), typeof(float))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(100.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Distance_formula_with_sqrt()
+	{
+		// distance = Sqrt((x2-x1)^2 + (y2-y1)^2)
+		// Sqrt((4-1)^2 + (5-1)^2) = Sqrt(9 + 16) = Sqrt(25) = 5
+		var dx = new SubtractResolver(
+			new VariantResolver(new Variant128(4.0), typeof(double)),
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		var dy = new SubtractResolver(
+			new VariantResolver(new Variant128(5.0), typeof(double)),
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		var resolver = new SqrtResolver(
+			new AddResolver(
+				new PowResolver(dx, new VariantResolver(new Variant128(2.0), typeof(double))),
+				new PowResolver(dy, new VariantResolver(new Variant128(2.0), typeof(double)))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(5.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Exponential_decay_formula()
+	{
+		// decay = initialValue * Pow(decayRate, time)
+		// 100 * Pow(0.5, 3) = 100 * 0.125 = 12.5
+		var resolver = new MultiplyResolver(
+			new VariantResolver(new Variant128(100.0), typeof(double)),
+			new PowResolver(
+				new VariantResolver(new Variant128(0.5), typeof(double)),
+				new VariantResolver(new Variant128(3.0), typeof(double))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(12.5);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Floor_for_grid_snapping()
+	{
+		// gridX = Floor(worldX / cellSize) * cellSize
+		// Floor(7.8 / 2.0) * 2.0 = Floor(3.9) * 2.0 = 3.0 * 2.0 = 6.0
+		var resolver = new MultiplyResolver(
+			new FloorResolver(
+				new DivideResolver(
+					new VariantResolver(new Variant128(7.8), typeof(double)),
+					new VariantResolver(new Variant128(2.0), typeof(double)))),
+			new VariantResolver(new Variant128(2.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(6.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Ceil_for_resource_cost_rounding_up()
+	{
+		// requiredItems = Ceil(totalCost / costPerItem)
+		// Ceil(10.0 / 3.0) = Ceil(3.333...) = 4.0
+		var resolver = new CeilResolver(
+			new DivideResolver(
+				new VariantResolver(new Variant128(10.0), typeof(double)),
+				new VariantResolver(new Variant128(3.0), typeof(double))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(4.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Truncate_for_integer_conversion()
+	{
+		// Convert float position to grid coordinate (always toward zero)
+		// Truncate(-7.8 / 2.0) = Truncate(-3.9) = -3.0
+		var resolver = new TruncateResolver(
+			new DivideResolver(
+				new VariantResolver(new Variant128(-7.8), typeof(double)),
+				new VariantResolver(new Variant128(2.0), typeof(double))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(-3.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Round_for_display_value()
+	{
+		// displayValue = Round(rawValue * 100) / 100 — but using Round directly
+		// Round(3.14159 * 1.0) = Round(3.14159) = 3.0
+		var resolver = new RoundResolver(
+			new VariantResolver(new Variant128(3.14159), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(3.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Effective_stat_with_min_cap()
+	{
+		// effectiveStat = Max(baseStat + modifier, minimumStat)
+		// Max(10 + (-15), 1) = Max(-5, 1) = 1
+		var resolver = new MaxResolver(
+			new AddResolver(
+				new VariantResolver(new Variant128(10), typeof(int)),
+				new VariantResolver(new Variant128(-15), typeof(int))),
+			new VariantResolver(new Variant128(1), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(1);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Damage_with_crit_floor()
+	{
+		// critDamage = Floor(baseDamage * critMultiplier)
+		// Floor(47.0 * 1.5) = Floor(70.5) = 70.0
+		var resolver = new FloorResolver(
+			new MultiplyResolver(
+				new VariantResolver(new Variant128(47.0), typeof(double)),
+				new VariantResolver(new Variant128(1.5), typeof(double))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(70.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Level_scaling_with_sqrt()
+	{
+		// scaledStat = baseStat + Floor(Sqrt(level) * growthRate)
+		// 10 + Floor(Sqrt(25.0) * 3.0) = 10 + Floor(5.0 * 3.0) = 10 + Floor(15.0) = 10 + 15.0 = 25.0
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(10.0), typeof(double)),
+			new FloorResolver(
+				new MultiplyResolver(
+					new SqrtResolver(
+						new VariantResolver(new Variant128(25.0), typeof(double))),
+					new VariantResolver(new Variant128(3.0), typeof(double)))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(25.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Experience_curve_with_pow()
+	{
+		// xpRequired = Floor(baseXP * Pow(level, exponent))
+		// Floor(100.0 * Pow(5.0, 1.5)) = Floor(100.0 * 11.1803...) = Floor(1118.03...) = 1118.0
+		var resolver = new FloorResolver(
+			new MultiplyResolver(
+				new VariantResolver(new Variant128(100.0), typeof(double)),
+				new PowResolver(
+					new VariantResolver(new Variant128(5.0), typeof(double)),
+					new VariantResolver(new Variant128(1.5), typeof(double)))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(1118.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Vector3_lerp_for_position_interpolation()
+	{
+		// Smoothly move between two positions at t=0.25
+		// Lerp((0,0,0), (8,4,12), 0.25) = (2, 1, 3)
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(new Vector3(0, 0, 0)), typeof(Vector3)),
+			new VariantResolver(new Variant128(new Vector3(8, 4, 12)), typeof(Vector3)),
+			new VariantResolver(new Variant128(0.25f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector3().Should().Be(new Vector3(2, 1, 3));
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Vector2_lerp_for_ui_animation()
+	{
+		// Animate a UI element from one position to another
+		// Lerp((10, 200), (300, 50), 0.5) = (155, 125)
+		var resolver = new LerpResolver(
+			new VariantResolver(new Variant128(new Vector2(10, 200)), typeof(Vector2)),
+			new VariantResolver(new Variant128(new Vector2(300, 50)), typeof(Vector2)),
+			new VariantResolver(new Variant128(0.5f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector2().Should().Be(new Vector2(155, 125));
+	}
 }

--- a/Forge.Tests/Statescript/Resolvers/MathResolversTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/MathResolversTests.cs
@@ -748,4 +748,209 @@ public class MathResolversTests
 
 		resolver.Resolve(context).AsVector2().Should().Be(new Vector2(155, 125));
 	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Sine_wave_oscillation()
+	{
+		// amplitude * Sin(frequency * time)
+		// 10.0 * Sin(2.0 * π/2) = 10.0 * Sin(π) ≈ 10.0 * 0.0 = 0.0
+		var resolver = new MultiplyResolver(
+			new VariantResolver(new Variant128(10.0), typeof(double)),
+			new SinResolver(
+				new MultiplyResolver(
+					new VariantResolver(new Variant128(2.0), typeof(double)),
+					new VariantResolver(new Variant128(Math.PI / 2.0), typeof(double)))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(0.0, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Angle_between_two_points_with_atan2()
+	{
+		// angle = ATan2(dy, dx)
+		// ATan2(3 - 0, 4 - 0) = ATan2(3, 4) ≈ 0.6435 radians
+		var resolver = new ATan2Resolver(
+			new SubtractResolver(
+				new VariantResolver(new Variant128(3.0), typeof(double)),
+				new VariantResolver(new Variant128(0.0), typeof(double))),
+			new SubtractResolver(
+				new VariantResolver(new Variant128(4.0), typeof(double)),
+				new VariantResolver(new Variant128(0.0), typeof(double))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(0.6435, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Exponential_growth_with_exp()
+	{
+		// population = initial * Exp(rate * time)
+		// 100 * Exp(0.1 * 10) = 100 * Exp(1) = 100 * e ≈ 271.83
+		var resolver = new MultiplyResolver(
+			new VariantResolver(new Variant128(100.0), typeof(double)),
+			new ExpResolver(
+				new MultiplyResolver(
+					new VariantResolver(new Variant128(0.1), typeof(double)),
+					new VariantResolver(new Variant128(10.0), typeof(double)))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(100.0 * Math.E, 0.01);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Logarithmic_scaling_for_difficulty()
+	{
+		// difficulty = baseValue + scaleFactor * Log(level)
+		// 10.0 + 5.0 * Log(e^2) = 10.0 + 5.0 * 2.0 = 20.0
+		var resolver = new AddResolver(
+			new VariantResolver(new Variant128(10.0), typeof(double)),
+			new MultiplyResolver(
+				new VariantResolver(new Variant128(5.0), typeof(double)),
+				new LogResolver(
+					new VariantResolver(new Variant128(Math.E * Math.E), typeof(double)))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(20.0, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Bit_depth_calculation_with_log2()
+	{
+		// bitsNeeded = Ceil(Log2(numValues))
+		// Ceil(Log2(1000)) = Ceil(9.9658) = 10.0
+		var resolver = new CeilResolver(
+			new Log2Resolver(
+				new VariantResolver(new Variant128(1000.0), typeof(double))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(10.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Decibel_calculation_with_log10()
+	{
+		// decibels = 20 * Log10(amplitude / reference)
+		// 20 * Log10(100 / 1) = 20 * Log10(100) = 20 * 2 = 40
+		var resolver = new MultiplyResolver(
+			new VariantResolver(new Variant128(20.0), typeof(double)),
+			new Log10Resolver(
+				new DivideResolver(
+					new VariantResolver(new Variant128(100.0), typeof(double)),
+					new VariantResolver(new Variant128(1.0), typeof(double)))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(40.0, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Smooth_step_approximation_with_tanh()
+	{
+		// smoothValue = (TanH(x) + 1) / 2 — maps (-∞,+∞) to (0, 1)
+		// (TanH(0) + 1) / 2 = (0 + 1) / 2 = 0.5
+		var resolver = new DivideResolver(
+			new AddResolver(
+				new TanHResolver(
+					new VariantResolver(new Variant128(0.0), typeof(double))),
+				new VariantResolver(new Variant128(1.0), typeof(double))),
+			new VariantResolver(new Variant128(2.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(0.5, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Direction_sign_with_copysign()
+	{
+		// Apply direction sign to speed: CopySign(speed, direction)
+		// CopySign(Abs(-7.5), -1.0) = CopySign(7.5, -1.0) = -7.5
+		var resolver = new CopySignResolver(
+			new AbsResolver(
+				new VariantResolver(new Variant128(-7.5), typeof(double))),
+			new VariantResolver(new Variant128(-1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(-7.5);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Cube_root_for_volume_to_side_length()
+	{
+		// sideLength = Cbrt(volume)
+		// Cbrt(27) = 3
+		var resolver = new CbrtResolver(
+			new VariantResolver(new Variant128(27.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(3.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Sign_for_movement_direction()
+	{
+		// direction = Sign(targetX - currentX)
+		// Sign(10 - 25) = Sign(-15) = -1
+		var resolver = new SignResolver(
+			new SubtractResolver(
+				new VariantResolver(new Variant128(10), typeof(int)),
+				new VariantResolver(new Variant128(25), typeof(int))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(-1);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Pythagorean_identity_sin_squared_plus_cos_squared()
+	{
+		// Sin²(x) + Cos²(x) = 1 for any x
+		var angle = new VariantResolver(new Variant128(0.7), typeof(double));
+
+		var resolver = new AddResolver(
+			new PowResolver(
+				new SinResolver(angle),
+				new VariantResolver(new Variant128(2.0), typeof(double))),
+			new PowResolver(
+				new CosResolver(angle),
+				new VariantResolver(new Variant128(2.0), typeof(double))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(1.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "MathComposition")]
+	public void Exp_and_log_are_inverses()
+	{
+		// Log(Exp(x)) = x
+		// Log(Exp(3.5)) = 3.5
+		var resolver = new LogResolver(
+			new ExpResolver(
+				new VariantResolver(new Variant128(3.5), typeof(double))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(3.5, 0.0001);
+	}
 }

--- a/Forge.Tests/Statescript/Resolvers/MaxResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/MaxResolverTests.cs
@@ -1,0 +1,207 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class MaxResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Max")]
+	public void Max_resolver_int_and_int_value_type_is_int()
+	{
+		var resolver = new MaxResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(5), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(int));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Max")]
+	public void Max_resolver_int_and_double_promotes_to_double()
+	{
+		var resolver = new MaxResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(5.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Max")]
+	public void Max_resolver_returns_larger_int()
+	{
+		var resolver = new MaxResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(3), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(10);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Max")]
+	public void Max_resolver_returns_larger_when_right_is_larger()
+	{
+		var resolver = new MaxResolver(
+			new VariantResolver(new Variant128(2), typeof(int)),
+			new VariantResolver(new Variant128(8), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(8);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Max")]
+	public void Max_resolver_equal_values_returns_that_value()
+	{
+		var resolver = new MaxResolver(
+			new VariantResolver(new Variant128(7), typeof(int)),
+			new VariantResolver(new Variant128(7), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(7);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Max")]
+	public void Max_resolver_negative_values()
+	{
+		var resolver = new MaxResolver(
+			new VariantResolver(new Variant128(-3), typeof(int)),
+			new VariantResolver(new Variant128(-10), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(-3);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Max")]
+	public void Max_resolver_computes_double_max()
+	{
+		var resolver = new MaxResolver(
+			new VariantResolver(new Variant128(3.14), typeof(double)),
+			new VariantResolver(new Variant128(2.71), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(3.14);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Max")]
+	public void Max_resolver_computes_float_max()
+	{
+		var resolver = new MaxResolver(
+			new VariantResolver(new Variant128(5.0f), typeof(float)),
+			new VariantResolver(new Variant128(3.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(5.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Max")]
+	public void Max_resolver_computes_long_max()
+	{
+		var resolver = new MaxResolver(
+			new VariantResolver(new Variant128(100L), typeof(long)),
+			new VariantResolver(new Variant128(50L), typeof(long)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsLong().Should().Be(100L);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Max")]
+	public void Max_resolver_computes_decimal_max()
+	{
+		var resolver = new MaxResolver(
+			new VariantResolver(new Variant128(10.5m), typeof(decimal)),
+			new VariantResolver(new Variant128(3.2m), typeof(decimal)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDecimal().Should().Be(10.5m);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Max")]
+	public void Max_resolver_mixed_int_and_double()
+	{
+		var resolver = new MaxResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(5.5), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(10.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Max")]
+	public void Max_resolver_supports_nesting()
+	{
+		// Max(Max(1, 5), 3) = Max(5, 3) = 5
+		var inner = new MaxResolver(
+			new VariantResolver(new Variant128(1), typeof(int)),
+			new VariantResolver(new Variant128(5), typeof(int)));
+
+		var outer = new MaxResolver(
+			inner,
+			new VariantResolver(new Variant128(3), typeof(int)));
+
+		var context = new GraphContext();
+
+		outer.Resolve(context).AsInt().Should().Be(5);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Max")]
+	public void Max_resolver_throws_for_vector_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new MaxResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)),
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Max")]
+	public void Max_resolver_throws_for_quaternion_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new MaxResolver(
+			new VariantResolver(new Variant128(Quaternion.Identity), typeof(Quaternion)),
+			new VariantResolver(new Variant128(Quaternion.Identity), typeof(Quaternion)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Max")]
+	public void Max_resolver_throws_for_bool_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new MaxResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)),
+			new VariantResolver(new Variant128(false), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/MinResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/MinResolverTests.cs
@@ -1,0 +1,207 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class MinResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Min")]
+	public void Min_resolver_int_and_int_value_type_is_int()
+	{
+		var resolver = new MinResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(5), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(int));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Min")]
+	public void Min_resolver_int_and_double_promotes_to_double()
+	{
+		var resolver = new MinResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(5.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Min")]
+	public void Min_resolver_returns_smaller_int()
+	{
+		var resolver = new MinResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(3), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(3);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Min")]
+	public void Min_resolver_returns_smaller_when_left_is_smaller()
+	{
+		var resolver = new MinResolver(
+			new VariantResolver(new Variant128(2), typeof(int)),
+			new VariantResolver(new Variant128(8), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(2);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Min")]
+	public void Min_resolver_equal_values_returns_that_value()
+	{
+		var resolver = new MinResolver(
+			new VariantResolver(new Variant128(7), typeof(int)),
+			new VariantResolver(new Variant128(7), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(7);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Min")]
+	public void Min_resolver_negative_values()
+	{
+		var resolver = new MinResolver(
+			new VariantResolver(new Variant128(-3), typeof(int)),
+			new VariantResolver(new Variant128(-10), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(-10);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Min")]
+	public void Min_resolver_computes_double_min()
+	{
+		var resolver = new MinResolver(
+			new VariantResolver(new Variant128(3.14), typeof(double)),
+			new VariantResolver(new Variant128(2.71), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(2.71);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Min")]
+	public void Min_resolver_computes_float_min()
+	{
+		var resolver = new MinResolver(
+			new VariantResolver(new Variant128(5.0f), typeof(float)),
+			new VariantResolver(new Variant128(3.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(3.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Min")]
+	public void Min_resolver_computes_long_min()
+	{
+		var resolver = new MinResolver(
+			new VariantResolver(new Variant128(100L), typeof(long)),
+			new VariantResolver(new Variant128(50L), typeof(long)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsLong().Should().Be(50L);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Min")]
+	public void Min_resolver_computes_decimal_min()
+	{
+		var resolver = new MinResolver(
+			new VariantResolver(new Variant128(10.5m), typeof(decimal)),
+			new VariantResolver(new Variant128(3.2m), typeof(decimal)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDecimal().Should().Be(3.2m);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Min")]
+	public void Min_resolver_mixed_int_and_double()
+	{
+		var resolver = new MinResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(5.5), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(5.5);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Min")]
+	public void Min_resolver_supports_nesting()
+	{
+		// Min(Min(10, 5), 3) = Min(5, 3) = 3
+		var inner = new MinResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(5), typeof(int)));
+
+		var outer = new MinResolver(
+			inner,
+			new VariantResolver(new Variant128(3), typeof(int)));
+
+		var context = new GraphContext();
+
+		outer.Resolve(context).AsInt().Should().Be(3);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Min")]
+	public void Min_resolver_throws_for_vector_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new MinResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)),
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Min")]
+	public void Min_resolver_throws_for_quaternion_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new MinResolver(
+			new VariantResolver(new Variant128(Quaternion.Identity), typeof(Quaternion)),
+			new VariantResolver(new Variant128(Quaternion.Identity), typeof(Quaternion)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Min")]
+	public void Min_resolver_throws_for_bool_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new MinResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)),
+			new VariantResolver(new Variant128(false), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/ModuloResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/ModuloResolverTests.cs
@@ -1,0 +1,195 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class ModuloResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Modulo")]
+	public void Modulo_resolver_int_mod_int_value_type_is_int()
+	{
+		var resolver = new ModuloResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(3), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(int));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Modulo")]
+	public void Modulo_resolver_int_mod_double_promotes_to_double()
+	{
+		var resolver = new ModuloResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(3.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Modulo")]
+	public void Modulo_resolver_computes_int_remainder()
+	{
+		var resolver = new ModuloResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(3), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(1);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Modulo")]
+	public void Modulo_resolver_computes_double_remainder()
+	{
+		var resolver = new ModuloResolver(
+			new VariantResolver(new Variant128(10.5), typeof(double)),
+			new VariantResolver(new Variant128(3.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(1.5, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Modulo")]
+	public void Modulo_resolver_computes_float_remainder()
+	{
+		var resolver = new ModuloResolver(
+			new VariantResolver(new Variant128(7.5f), typeof(float)),
+			new VariantResolver(new Variant128(2.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(1.5f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Modulo")]
+	public void Modulo_resolver_computes_long_remainder()
+	{
+		var resolver = new ModuloResolver(
+			new VariantResolver(new Variant128(17L), typeof(long)),
+			new VariantResolver(new Variant128(5L), typeof(long)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsLong().Should().Be(2L);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Modulo")]
+	public void Modulo_resolver_computes_decimal_remainder()
+	{
+		var resolver = new ModuloResolver(
+			new VariantResolver(new Variant128(10.5m), typeof(decimal)),
+			new VariantResolver(new Variant128(3.0m), typeof(decimal)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDecimal().Should().Be(1.5m);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Modulo")]
+	public void Modulo_resolver_zero_remainder()
+	{
+		var resolver = new ModuloResolver(
+			new VariantResolver(new Variant128(12), typeof(int)),
+			new VariantResolver(new Variant128(4), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Modulo")]
+	public void Modulo_resolver_negative_dividend()
+	{
+		var resolver = new ModuloResolver(
+			new VariantResolver(new Variant128(-10), typeof(int)),
+			new VariantResolver(new Variant128(3), typeof(int)));
+
+		var context = new GraphContext();
+
+		// C# % follows truncation toward zero: -10 % 3 = -1
+		resolver.Resolve(context).AsInt().Should().Be(-1);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Modulo")]
+	public void Modulo_resolver_byte_mod_short_promotes_to_int()
+	{
+		var resolver = new ModuloResolver(
+			new VariantResolver(new Variant128((byte)25), typeof(byte)),
+			new VariantResolver(new Variant128((short)7), typeof(short)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(4);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Modulo")]
+	public void Modulo_resolver_supports_nesting()
+	{
+		// (17 % 5) % 2 = 2 % 2 = 0
+		var inner = new ModuloResolver(
+			new VariantResolver(new Variant128(17), typeof(int)),
+			new VariantResolver(new Variant128(5), typeof(int)));
+
+		var outer = new ModuloResolver(
+			inner,
+			new VariantResolver(new Variant128(2), typeof(int)));
+
+		var context = new GraphContext();
+
+		outer.Resolve(context).AsInt().Should().Be(0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Modulo")]
+	public void Modulo_resolver_throws_for_vector_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ModuloResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)),
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Modulo")]
+	public void Modulo_resolver_throws_for_quaternion_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ModuloResolver(
+			new VariantResolver(new Variant128(Quaternion.Identity), typeof(Quaternion)),
+			new VariantResolver(new Variant128(Quaternion.Identity), typeof(Quaternion)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Modulo")]
+	public void Modulo_resolver_throws_for_bool_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new ModuloResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)),
+			new VariantResolver(new Variant128(false), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/MultiplyResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/MultiplyResolverTests.cs
@@ -1,0 +1,260 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class MultiplyResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Multiply")]
+	public void Multiply_resolver_int_times_int_value_type_is_int()
+	{
+		var resolver = new MultiplyResolver(
+			new VariantResolver(new Variant128(3), typeof(int)),
+			new VariantResolver(new Variant128(4), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(int));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Multiply")]
+	public void Multiply_resolver_int_times_float_promotes_to_float()
+	{
+		var resolver = new MultiplyResolver(
+			new VariantResolver(new Variant128(3), typeof(int)),
+			new VariantResolver(new Variant128(2.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Multiply")]
+	public void Multiply_resolver_vector3_times_vector3_value_type_is_vector3()
+	{
+		var resolver = new MultiplyResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)),
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+
+		resolver.ValueType.Should().Be(typeof(Vector3));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Multiply")]
+	public void Multiply_resolver_multiplies_two_ints()
+	{
+		var resolver = new MultiplyResolver(
+			new VariantResolver(new Variant128(6), typeof(int)),
+			new VariantResolver(new Variant128(7), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(42);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Multiply")]
+	public void Multiply_resolver_multiplies_two_doubles()
+	{
+		var resolver = new MultiplyResolver(
+			new VariantResolver(new Variant128(2.5), typeof(double)),
+			new VariantResolver(new Variant128(4.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(10.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Multiply")]
+	public void Multiply_resolver_multiplies_two_floats()
+	{
+		var resolver = new MultiplyResolver(
+			new VariantResolver(new Variant128(3.0f), typeof(float)),
+			new VariantResolver(new Variant128(2.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(6.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Multiply")]
+	public void Multiply_resolver_multiplies_two_longs()
+	{
+		var resolver = new MultiplyResolver(
+			new VariantResolver(new Variant128(100L), typeof(long)),
+			new VariantResolver(new Variant128(200L), typeof(long)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsLong().Should().Be(20000L);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Multiply")]
+	public void Multiply_resolver_multiplies_two_decimals()
+	{
+		var resolver = new MultiplyResolver(
+			new VariantResolver(new Variant128(2.5m), typeof(decimal)),
+			new VariantResolver(new Variant128(4.0m), typeof(decimal)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDecimal().Should().Be(10.0m);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Multiply")]
+	public void Multiply_resolver_multiplies_int_and_double()
+	{
+		var resolver = new MultiplyResolver(
+			new VariantResolver(new Variant128(3), typeof(int)),
+			new VariantResolver(new Variant128(2.5), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(7.5);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Multiply")]
+	public void Multiply_resolver_by_zero_returns_zero()
+	{
+		var resolver = new MultiplyResolver(
+			new VariantResolver(new Variant128(42), typeof(int)),
+			new VariantResolver(new Variant128(0), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Multiply")]
+	public void Multiply_resolver_by_one_returns_same_value()
+	{
+		var resolver = new MultiplyResolver(
+			new VariantResolver(new Variant128(42), typeof(int)),
+			new VariantResolver(new Variant128(1), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(42);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Multiply")]
+	public void Multiply_resolver_negative_times_positive()
+	{
+		var resolver = new MultiplyResolver(
+			new VariantResolver(new Variant128(-5), typeof(int)),
+			new VariantResolver(new Variant128(3), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(-15);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Multiply")]
+	public void Multiply_resolver_multiplies_two_vector2_componentwise()
+	{
+		var resolver = new MultiplyResolver(
+			new VariantResolver(new Variant128(new Vector2(2, 3)), typeof(Vector2)),
+			new VariantResolver(new Variant128(new Vector2(4, 5)), typeof(Vector2)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector2().Should().Be(new Vector2(8, 15));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Multiply")]
+	public void Multiply_resolver_multiplies_two_vector3_componentwise()
+	{
+		var resolver = new MultiplyResolver(
+			new VariantResolver(new Variant128(new Vector3(1, 2, 3)), typeof(Vector3)),
+			new VariantResolver(new Variant128(new Vector3(4, 5, 6)), typeof(Vector3)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector3().Should().Be(new Vector3(4, 10, 18));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Multiply")]
+	public void Multiply_resolver_multiplies_two_vector4_componentwise()
+	{
+		var resolver = new MultiplyResolver(
+			new VariantResolver(new Variant128(new Vector4(1, 2, 3, 4)), typeof(Vector4)),
+			new VariantResolver(new Variant128(new Vector4(2, 2, 2, 2)), typeof(Vector4)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector4().Should().Be(new Vector4(2, 4, 6, 8));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Multiply")]
+	public void Multiply_resolver_multiplies_two_quaternions()
+	{
+		var left = new Quaternion(1, 0, 0, 1);
+		var right = new Quaternion(0, 1, 0, 1);
+
+		var resolver = new MultiplyResolver(
+			new VariantResolver(new Variant128(left), typeof(Quaternion)),
+			new VariantResolver(new Variant128(right), typeof(Quaternion)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsQuaternion().Should().Be(left * right);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Multiply")]
+	public void Multiply_resolver_supports_nesting()
+	{
+		// (2 * 3) * 4 = 24
+		var inner = new MultiplyResolver(
+			new VariantResolver(new Variant128(2), typeof(int)),
+			new VariantResolver(new Variant128(3), typeof(int)));
+
+		var outer = new MultiplyResolver(
+			inner,
+			new VariantResolver(new Variant128(4), typeof(int)));
+
+		var context = new GraphContext();
+
+		outer.Resolve(context).AsInt().Should().Be(24);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Multiply")]
+	public void Multiply_resolver_throws_for_bool_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new MultiplyResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)),
+			new VariantResolver(new Variant128(false), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Multiply")]
+	public void Multiply_resolver_throws_for_mismatched_vector_types()
+	{
+#pragma warning disable CA1806
+		Action act = () => new MultiplyResolver(
+			new VariantResolver(new Variant128(Vector2.One), typeof(Vector2)),
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/NegateResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/NegateResolverTests.cs
@@ -1,0 +1,224 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class NegateResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Negate")]
+	public void Negate_resolver_int_value_type_is_int()
+	{
+		var resolver = new NegateResolver(
+			new VariantResolver(new Variant128(5), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(int));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Negate")]
+	public void Negate_resolver_double_value_type_is_double()
+	{
+		var resolver = new NegateResolver(
+			new VariantResolver(new Variant128(5.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Negate")]
+	public void Negate_resolver_byte_promotes_to_int()
+	{
+		var resolver = new NegateResolver(
+			new VariantResolver(new Variant128((byte)10), typeof(byte)));
+
+		resolver.ValueType.Should().Be(typeof(int));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Negate")]
+	public void Negate_resolver_vector3_value_type_is_vector3()
+	{
+		var resolver = new NegateResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+
+		resolver.ValueType.Should().Be(typeof(Vector3));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Negate")]
+	public void Negate_resolver_negates_positive_int()
+	{
+		var resolver = new NegateResolver(
+			new VariantResolver(new Variant128(42), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(-42);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Negate")]
+	public void Negate_resolver_negates_negative_int()
+	{
+		var resolver = new NegateResolver(
+			new VariantResolver(new Variant128(-42), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(42);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Negate")]
+	public void Negate_resolver_negates_double()
+	{
+		var resolver = new NegateResolver(
+			new VariantResolver(new Variant128(3.14), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(-3.14);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Negate")]
+	public void Negate_resolver_negates_float()
+	{
+		var resolver = new NegateResolver(
+			new VariantResolver(new Variant128(2.5f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(-2.5f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Negate")]
+	public void Negate_resolver_negates_long()
+	{
+		var resolver = new NegateResolver(
+			new VariantResolver(new Variant128(100L), typeof(long)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsLong().Should().Be(-100L);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Negate")]
+	public void Negate_resolver_negates_decimal()
+	{
+		var resolver = new NegateResolver(
+			new VariantResolver(new Variant128(7.5m), typeof(decimal)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDecimal().Should().Be(-7.5m);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Negate")]
+	public void Negate_resolver_negates_byte_as_int()
+	{
+		var resolver = new NegateResolver(
+			new VariantResolver(new Variant128((byte)10), typeof(byte)));
+
+		var context = new GraphContext();
+
+		// byte promotes to int, then negated
+		resolver.Resolve(context).AsInt().Should().Be(-10);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Negate")]
+	public void Negate_resolver_zero_returns_zero()
+	{
+		var resolver = new NegateResolver(
+			new VariantResolver(new Variant128(0), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Negate")]
+	public void Negate_resolver_negates_vector2()
+	{
+		var resolver = new NegateResolver(
+			new VariantResolver(new Variant128(new Vector2(1, -2)), typeof(Vector2)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector2().Should().Be(new Vector2(-1, 2));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Negate")]
+	public void Negate_resolver_negates_vector3()
+	{
+		var resolver = new NegateResolver(
+			new VariantResolver(new Variant128(new Vector3(1, -2, 3)), typeof(Vector3)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector3().Should().Be(new Vector3(-1, 2, -3));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Negate")]
+	public void Negate_resolver_negates_vector4()
+	{
+		var resolver = new NegateResolver(
+			new VariantResolver(new Variant128(new Vector4(1, -2, 3, -4)), typeof(Vector4)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector4().Should().Be(new Vector4(-1, 2, -3, 4));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Negate")]
+	public void Negate_resolver_negates_quaternion()
+	{
+		var q = new Quaternion(1, -2, 3, -4);
+
+		var resolver = new NegateResolver(
+			new VariantResolver(new Variant128(q), typeof(Quaternion)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsQuaternion().Should().Be(-q);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Negate")]
+	public void Negate_resolver_double_negate_returns_original()
+	{
+		var inner = new NegateResolver(
+			new VariantResolver(new Variant128(42), typeof(int)));
+
+		var outer = new NegateResolver(inner);
+
+		var context = new GraphContext();
+
+		outer.Resolve(context).AsInt().Should().Be(42);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Negate")]
+	public void Negate_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new NegateResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/PiResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/PiResolverTests.cs
@@ -1,0 +1,104 @@
+// Copyright © Gamesmiths Guild.
+
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class PiResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Pi")]
+	public void Pi_resolver_default_value_type_is_double()
+	{
+		var resolver = new PiResolver();
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pi")]
+	public void Pi_resolver_explicit_double_value_type_is_double()
+	{
+		var resolver = new PiResolver(typeof(double));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pi")]
+	public void Pi_resolver_explicit_float_value_type_is_float()
+	{
+		var resolver = new PiResolver(typeof(float));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pi")]
+	public void Pi_resolver_double_returns_math_pi()
+	{
+		var resolver = new PiResolver();
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(Math.PI);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pi")]
+	public void Pi_resolver_float_returns_mathf_pi()
+	{
+		var resolver = new PiResolver(typeof(float));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(MathF.PI);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pi")]
+	public void Pi_resolver_value_is_approximately_3_14159()
+	{
+		var resolver = new PiResolver();
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(3.14159, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pi")]
+	public void Pi_resolver_throws_for_int_type()
+	{
+#pragma warning disable CA1806
+		Action act = () => new PiResolver(typeof(int));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pi")]
+	public void Pi_resolver_throws_for_decimal_type()
+	{
+#pragma warning disable CA1806
+		Action act = () => new PiResolver(typeof(decimal));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pi")]
+	public void Pi_resolver_usable_in_composition()
+	{
+		// Sin(Pi) ≈ 0
+		var resolver = new SinResolver(new PiResolver());
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(0.0, 0.0001);
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/PowResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/PowResolverTests.cs
@@ -1,0 +1,191 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class PowResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Pow")]
+	public void Pow_resolver_float_operands_value_type_is_float()
+	{
+		var resolver = new PowResolver(
+			new VariantResolver(new Variant128(2.0f), typeof(float)),
+			new VariantResolver(new Variant128(3.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pow")]
+	public void Pow_resolver_double_operands_value_type_is_double()
+	{
+		var resolver = new PowResolver(
+			new VariantResolver(new Variant128(2.0), typeof(double)),
+			new VariantResolver(new Variant128(3.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pow")]
+	public void Pow_resolver_int_operands_promotes_to_double()
+	{
+		var resolver = new PowResolver(
+			new VariantResolver(new Variant128(2), typeof(int)),
+			new VariantResolver(new Variant128(3), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pow")]
+	public void Pow_resolver_mixed_float_and_double_promotes_to_double()
+	{
+		var resolver = new PowResolver(
+			new VariantResolver(new Variant128(2.0f), typeof(float)),
+			new VariantResolver(new Variant128(3.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pow")]
+	public void Pow_resolver_computes_float_power()
+	{
+		var resolver = new PowResolver(
+			new VariantResolver(new Variant128(2.0f), typeof(float)),
+			new VariantResolver(new Variant128(3.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(8.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pow")]
+	public void Pow_resolver_computes_double_power()
+	{
+		var resolver = new PowResolver(
+			new VariantResolver(new Variant128(2.0), typeof(double)),
+			new VariantResolver(new Variant128(10.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(1024.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pow")]
+	public void Pow_resolver_computes_int_power_as_double()
+	{
+		var resolver = new PowResolver(
+			new VariantResolver(new Variant128(3), typeof(int)),
+			new VariantResolver(new Variant128(4), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(81.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pow")]
+	public void Pow_resolver_zero_exponent_returns_one()
+	{
+		var resolver = new PowResolver(
+			new VariantResolver(new Variant128(5.0), typeof(double)),
+			new VariantResolver(new Variant128(0.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(1.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pow")]
+	public void Pow_resolver_exponent_one_returns_base()
+	{
+		var resolver = new PowResolver(
+			new VariantResolver(new Variant128(7.0), typeof(double)),
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(7.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pow")]
+	public void Pow_resolver_fractional_exponent()
+	{
+		// 4^0.5 = 2
+		var resolver = new PowResolver(
+			new VariantResolver(new Variant128(4.0), typeof(double)),
+			new VariantResolver(new Variant128(0.5), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(2.0, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pow")]
+	public void Pow_resolver_supports_nesting()
+	{
+		// Pow(Pow(2, 3), 2) = Pow(8, 2) = 64
+		var inner = new PowResolver(
+			new VariantResolver(new Variant128(2.0), typeof(double)),
+			new VariantResolver(new Variant128(3.0), typeof(double)));
+
+		var outer = new PowResolver(
+			inner,
+			new VariantResolver(new Variant128(2.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		outer.Resolve(context).AsDouble().Should().Be(64.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pow")]
+	public void Pow_resolver_throws_for_decimal_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new PowResolver(
+			new VariantResolver(new Variant128(2.0m), typeof(decimal)),
+			new VariantResolver(new Variant128(3.0m), typeof(decimal)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pow")]
+	public void Pow_resolver_throws_for_vector_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new PowResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)),
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pow")]
+	public void Pow_resolver_throws_for_bool_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new PowResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)),
+			new VariantResolver(new Variant128(false), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/RadToDegResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/RadToDegResolverTests.cs
@@ -1,0 +1,175 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class RadToDegResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "RadToDeg")]
+	public void RadToDeg_resolver_float_value_type_is_float()
+	{
+		var resolver = new RadToDegResolver(
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "RadToDeg")]
+	public void RadToDeg_resolver_double_value_type_is_double()
+	{
+		var resolver = new RadToDegResolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "RadToDeg")]
+	public void RadToDeg_resolver_int_promotes_to_double()
+	{
+		var resolver = new RadToDegResolver(
+			new VariantResolver(new Variant128(1), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "RadToDeg")]
+	public void RadToDeg_resolver_zero_returns_zero()
+	{
+		var resolver = new RadToDegResolver(
+			new VariantResolver(new Variant128(0.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(0.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "RadToDeg")]
+	public void RadToDeg_resolver_pi_over_2_returns_90()
+	{
+		var resolver = new RadToDegResolver(
+			new VariantResolver(new Variant128(Math.PI / 2.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(90.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "RadToDeg")]
+	public void RadToDeg_resolver_pi_returns_180()
+	{
+		var resolver = new RadToDegResolver(
+			new VariantResolver(new Variant128(Math.PI), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(180.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "RadToDeg")]
+	public void RadToDeg_resolver_two_pi_returns_360()
+	{
+		var resolver = new RadToDegResolver(
+			new VariantResolver(new Variant128(2.0 * Math.PI), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(360.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "RadToDeg")]
+	public void RadToDeg_resolver_pi_over_4_returns_45()
+	{
+		var resolver = new RadToDegResolver(
+			new VariantResolver(new Variant128(Math.PI / 4.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(45.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "RadToDeg")]
+	public void RadToDeg_resolver_negative_radians()
+	{
+		var resolver = new RadToDegResolver(
+			new VariantResolver(new Variant128(-Math.PI / 2.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(-90.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "RadToDeg")]
+	public void RadToDeg_resolver_float_pi_over_2()
+	{
+		var resolver = new RadToDegResolver(
+			new VariantResolver(new Variant128(MathF.PI / 2.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().BeApproximately(90.0f, 0.01f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "RadToDeg")]
+	public void RadToDeg_and_DegToRad_are_inverses()
+	{
+		// RadToDeg(DegToRad(45)) = 45
+		var resolver = new RadToDegResolver(
+			new DegToRadResolver(
+				new VariantResolver(new Variant128(45.0), typeof(double))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(45.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "RadToDeg")]
+	public void RadToDeg_resolver_throws_for_decimal_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new RadToDegResolver(
+			new VariantResolver(new Variant128(1.0m), typeof(decimal)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "RadToDeg")]
+	public void RadToDeg_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new RadToDegResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "RadToDeg")]
+	public void RadToDeg_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new RadToDegResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/RandomResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/RandomResolverTests.cs
@@ -1,0 +1,261 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Core;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class RandomResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Random")]
+	public void Random_resolver_int_operands_value_type_is_int()
+	{
+		var resolver = new RandomResolver(
+			new FixedRandom(),
+			new VariantResolver(new Variant128(0), typeof(int)),
+			new VariantResolver(new Variant128(10), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(int));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Random")]
+	public void Random_resolver_float_operands_value_type_is_float()
+	{
+		var resolver = new RandomResolver(
+			new FixedRandom(),
+			new VariantResolver(new Variant128(0.0f), typeof(float)),
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Random")]
+	public void Random_resolver_double_operands_value_type_is_double()
+	{
+		var resolver = new RandomResolver(
+			new FixedRandom(),
+			new VariantResolver(new Variant128(0.0), typeof(double)),
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Random")]
+	public void Random_resolver_mixed_int_float_promotes_to_float()
+	{
+		var resolver = new RandomResolver(
+			new FixedRandom(),
+			new VariantResolver(new Variant128(0), typeof(int)),
+			new VariantResolver(new Variant128(10.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Random")]
+	public void Random_resolver_int_range_uses_next_int()
+	{
+		// FixedRandom.NextInt(0, 10) returns 7
+		var resolver = new RandomResolver(
+			new FixedRandom(nextInt: 7),
+			new VariantResolver(new Variant128(0), typeof(int)),
+			new VariantResolver(new Variant128(10), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(7);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Random")]
+	public void Random_resolver_float_range_with_zero_random()
+	{
+		// NextSingle returns 0.0 → min + 0 * (max - min) = min = 5.0f
+		var resolver = new RandomResolver(
+			new FixedRandom(nextSingle: 0.0f),
+			new VariantResolver(new Variant128(5.0f), typeof(float)),
+			new VariantResolver(new Variant128(15.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(5.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Random")]
+	public void Random_resolver_float_range_with_half_random()
+	{
+		// NextSingle returns 0.5 → 5 + 0.5 * (15 - 5) = 5 + 5 = 10
+		var resolver = new RandomResolver(
+			new FixedRandom(nextSingle: 0.5f),
+			new VariantResolver(new Variant128(5.0f), typeof(float)),
+			new VariantResolver(new Variant128(15.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(10.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Random")]
+	public void Random_resolver_double_range_with_zero_random()
+	{
+		// NextDouble returns 0.0 → min
+		var resolver = new RandomResolver(
+			new FixedRandom(nextDouble: 0.0),
+			new VariantResolver(new Variant128(10.0), typeof(double)),
+			new VariantResolver(new Variant128(20.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(10.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Random")]
+	public void Random_resolver_double_range_with_full_random()
+	{
+		// NextDouble returns 0.999 → approaches max
+		var resolver = new RandomResolver(
+			new FixedRandom(nextDouble: 0.999),
+			new VariantResolver(new Variant128(0.0), typeof(double)),
+			new VariantResolver(new Variant128(100.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(99.9, 0.01);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Random")]
+	public void Random_resolver_supports_nesting_in_bounds()
+	{
+		// Random(0, 5 + 5) with fixed value → Random(0, 10)
+		var resolver = new RandomResolver(
+			new FixedRandom(nextInt: 3),
+			new VariantResolver(new Variant128(0), typeof(int)),
+			new AddResolver(
+				new VariantResolver(new Variant128(5), typeof(int)),
+				new VariantResolver(new Variant128(5), typeof(int))));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(3);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Random")]
+	public void Random_resolver_throws_for_decimal_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new RandomResolver(
+			new FixedRandom(),
+			new VariantResolver(new Variant128(0.0m), typeof(decimal)),
+			new VariantResolver(new Variant128(1.0m), typeof(decimal)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Random")]
+	public void Random_resolver_throws_for_vector_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new RandomResolver(
+			new FixedRandom(),
+			new VariantResolver(new Variant128(Vector3.Zero), typeof(Vector3)),
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Random")]
+	public void Random_resolver_throws_for_long_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new RandomResolver(
+			new FixedRandom(),
+			new VariantResolver(new Variant128(0L), typeof(long)),
+			new VariantResolver(new Variant128(10L), typeof(long)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Random")]
+	public void Random_resolver_throws_for_bool_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new RandomResolver(
+			new FixedRandom(),
+			new VariantResolver(new Variant128(true), typeof(bool)),
+			new VariantResolver(new Variant128(false), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	private sealed class FixedRandom(int nextInt = 0, float nextSingle = 0.0f, double nextDouble = 0.0) : IRandom
+	{
+		public int NextInt()
+		{
+			return nextInt;
+		}
+
+		public int NextInt(int maxValue)
+		{
+			return nextInt;
+		}
+
+		public int NextInt(int minValue, int maxValue)
+		{
+			return nextInt;
+		}
+
+		public float NextSingle()
+		{
+			return nextSingle;
+		}
+
+		public double NextDouble()
+		{
+			return nextDouble;
+		}
+
+		public long NextInt64()
+		{
+			throw new NotImplementedException();
+		}
+
+		public long NextInt64(long maxValue)
+		{
+			throw new NotImplementedException();
+		}
+
+		public long NextInt64(long minValue, long maxValue)
+		{
+			throw new NotImplementedException();
+		}
+
+		public void NextBytes(byte[] buffer)
+		{
+			throw new NotImplementedException();
+		}
+
+		public void NextBytes(Span<byte> buffer)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/RandomResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/RandomResolverTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Gamesmiths.Forge.Core;
 using Gamesmiths.Forge.Statescript;
 using Gamesmiths.Forge.Statescript.Properties;
+using Gamesmiths.Forge.Tests.Helpers;
 
 namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
 
@@ -204,58 +205,5 @@ public class RandomResolverTests
 #pragma warning restore CA1806
 
 		act.Should().Throw<ArgumentException>();
-	}
-
-	private sealed class FixedRandom(int nextInt = 0, float nextSingle = 0.0f, double nextDouble = 0.0) : IRandom
-	{
-		public int NextInt()
-		{
-			return nextInt;
-		}
-
-		public int NextInt(int maxValue)
-		{
-			return nextInt;
-		}
-
-		public int NextInt(int minValue, int maxValue)
-		{
-			return nextInt;
-		}
-
-		public float NextSingle()
-		{
-			return nextSingle;
-		}
-
-		public double NextDouble()
-		{
-			return nextDouble;
-		}
-
-		public long NextInt64()
-		{
-			throw new NotImplementedException();
-		}
-
-		public long NextInt64(long maxValue)
-		{
-			throw new NotImplementedException();
-		}
-
-		public long NextInt64(long minValue, long maxValue)
-		{
-			throw new NotImplementedException();
-		}
-
-		public void NextBytes(byte[] buffer)
-		{
-			throw new NotImplementedException();
-		}
-
-		public void NextBytes(Span<byte> buffer)
-		{
-			throw new NotImplementedException();
-		}
 	}
 }

--- a/Forge.Tests/Statescript/Resolvers/RoundResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/RoundResolverTests.cs
@@ -1,0 +1,203 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class RoundResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_float_value_type_is_float()
+	{
+		var resolver = new RoundResolver(
+			new VariantResolver(new Variant128(2.5f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_double_value_type_is_double()
+	{
+		var resolver = new RoundResolver(
+			new VariantResolver(new Variant128(2.5), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_decimal_value_type_is_decimal()
+	{
+		var resolver = new RoundResolver(
+			new VariantResolver(new Variant128(2.5m), typeof(decimal)));
+
+		resolver.ValueType.Should().Be(typeof(decimal));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_rounds_up_float()
+	{
+		var resolver = new RoundResolver(
+			new VariantResolver(new Variant128(2.7f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(3.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_rounds_down_float()
+	{
+		var resolver = new RoundResolver(
+			new VariantResolver(new Variant128(2.3f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(2.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_bankers_rounding_even_float()
+	{
+		// 2.5 rounds to 2 (banker's rounding: round to even)
+		var resolver = new RoundResolver(
+			new VariantResolver(new Variant128(2.5f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(2.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_bankers_rounding_odd_float()
+	{
+		// 3.5 rounds to 4 (banker's rounding: round to even)
+		var resolver = new RoundResolver(
+			new VariantResolver(new Variant128(3.5f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(4.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_positive_double()
+	{
+		var resolver = new RoundResolver(
+			new VariantResolver(new Variant128(3.7), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(4.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_negative_double()
+	{
+		var resolver = new RoundResolver(
+			new VariantResolver(new Variant128(-2.3), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(-2.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_positive_decimal()
+	{
+		var resolver = new RoundResolver(
+			new VariantResolver(new Variant128(5.6m), typeof(decimal)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDecimal().Should().Be(6.0m);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_negative_decimal()
+	{
+		var resolver = new RoundResolver(
+			new VariantResolver(new Variant128(-5.4m), typeof(decimal)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDecimal().Should().Be(-5.0m);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_whole_number_returns_same()
+	{
+		var resolver = new RoundResolver(
+			new VariantResolver(new Variant128(5.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(5.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_supports_nesting()
+	{
+		// Round(2.3 + 0.3) = Round(2.6) = 3.0
+		var sum = new AddResolver(
+			new VariantResolver(new Variant128(2.3), typeof(double)),
+			new VariantResolver(new Variant128(0.3), typeof(double)));
+
+		var resolver = new RoundResolver(sum);
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(3.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_throws_for_int_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new RoundResolver(
+			new VariantResolver(new Variant128(5), typeof(int)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new RoundResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new RoundResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/RoundResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/RoundResolverTests.cs
@@ -200,4 +200,143 @@ public class RoundResolverTests
 
 		act.Should().Throw<ArgumentException>();
 	}
+
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_with_digits_rounds_to_specified_decimal_places()
+	{
+		// Round(3.14159, 2) = 3.14
+		var resolver = new RoundResolver(
+			new VariantResolver(new Variant128(3.14159), typeof(double)),
+			digits: 2);
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(3.14);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_with_digits_one_place()
+	{
+		// Round(2.75, 1) = 2.8 (banker's rounding: 2.75 → 2.8 because 8 is even)
+		var resolver = new RoundResolver(
+			new VariantResolver(new Variant128(2.76), typeof(double)),
+			digits: 1);
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(2.8);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_with_away_from_zero_mode()
+	{
+		// Round(2.5, AwayFromZero) = 3 (not 2 like banker's rounding)
+		var resolver = new RoundResolver(
+			new VariantResolver(new Variant128(2.5), typeof(double)),
+			mode: MidpointRounding.AwayFromZero);
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(3.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_with_away_from_zero_negative()
+	{
+		// Round(-2.5, AwayFromZero) = -3
+		var resolver = new RoundResolver(
+			new VariantResolver(new Variant128(-2.5), typeof(double)),
+			mode: MidpointRounding.AwayFromZero);
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(-3.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_with_digits_and_mode()
+	{
+		// Round(2.345, 2, AwayFromZero) = 2.35
+		var resolver = new RoundResolver(
+			new VariantResolver(new Variant128(2.345), typeof(double)),
+			digits: 2,
+			mode: MidpointRounding.AwayFromZero);
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(2.35);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_float_with_digits()
+	{
+		// Round(3.14159f, 2) = 3.14f
+		var resolver = new RoundResolver(
+			new VariantResolver(new Variant128(3.14159f), typeof(float)),
+			digits: 2);
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().BeApproximately(3.14f, 0.001f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_decimal_with_digits()
+	{
+		// Round(3.14159m, 3) = 3.142m
+		var resolver = new RoundResolver(
+			new VariantResolver(new Variant128(3.14159m), typeof(decimal)),
+			digits: 3);
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDecimal().Should().Be(3.142m);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_default_parameters_preserve_original_behavior()
+	{
+		// Default: digits=0, mode=ToEven → same as original behavior
+		// Round(2.5) = 2.0 (banker's rounding)
+		var resolver = new RoundResolver(
+			new VariantResolver(new Variant128(2.5), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(2.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_throws_for_negative_digits()
+	{
+#pragma warning disable CA1806
+		Action act = () => new RoundResolver(
+			new VariantResolver(new Variant128(3.14), typeof(double)),
+			digits: -1);
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentOutOfRangeException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Round")]
+	public void Round_resolver_throws_for_digits_above_15()
+	{
+#pragma warning disable CA1806
+		Action act = () => new RoundResolver(
+			new VariantResolver(new Variant128(3.14), typeof(double)),
+			digits: 16);
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentOutOfRangeException>();
+	}
 }

--- a/Forge.Tests/Statescript/Resolvers/SignResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/SignResolverTests.cs
@@ -1,0 +1,201 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class SignResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Sign")]
+	public void Sign_resolver_value_type_is_always_int()
+	{
+		var floatResolver = new SignResolver(
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+
+		var doubleResolver = new SignResolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		var intResolver = new SignResolver(
+			new VariantResolver(new Variant128(1), typeof(int)));
+
+		floatResolver.ValueType.Should().Be(typeof(int));
+		doubleResolver.ValueType.Should().Be(typeof(int));
+		intResolver.ValueType.Should().Be(typeof(int));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sign")]
+	public void Sign_resolver_positive_float_returns_one()
+	{
+		var resolver = new SignResolver(
+			new VariantResolver(new Variant128(5.5f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(1);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sign")]
+	public void Sign_resolver_negative_float_returns_negative_one()
+	{
+		var resolver = new SignResolver(
+			new VariantResolver(new Variant128(-3.7f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(-1);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sign")]
+	public void Sign_resolver_zero_float_returns_zero()
+	{
+		var resolver = new SignResolver(
+			new VariantResolver(new Variant128(0.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sign")]
+	public void Sign_resolver_positive_double_returns_one()
+	{
+		var resolver = new SignResolver(
+			new VariantResolver(new Variant128(42.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(1);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sign")]
+	public void Sign_resolver_negative_double_returns_negative_one()
+	{
+		var resolver = new SignResolver(
+			new VariantResolver(new Variant128(-0.001), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(-1);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sign")]
+	public void Sign_resolver_positive_int_returns_one()
+	{
+		var resolver = new SignResolver(
+			new VariantResolver(new Variant128(100), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(1);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sign")]
+	public void Sign_resolver_negative_int_returns_negative_one()
+	{
+		var resolver = new SignResolver(
+			new VariantResolver(new Variant128(-50), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(-1);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sign")]
+	public void Sign_resolver_zero_int_returns_zero()
+	{
+		var resolver = new SignResolver(
+			new VariantResolver(new Variant128(0), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sign")]
+	public void Sign_resolver_positive_decimal_returns_one()
+	{
+		var resolver = new SignResolver(
+			new VariantResolver(new Variant128(9.99m), typeof(decimal)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(1);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sign")]
+	public void Sign_resolver_negative_long_returns_negative_one()
+	{
+		var resolver = new SignResolver(
+			new VariantResolver(new Variant128(-999L), typeof(long)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(-1);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sign")]
+	public void Sign_resolver_supports_nesting()
+	{
+		// Sign(Sign(-5.0)) = Sign(-1) — but Sign returns int, and Sign(int 1) = 1
+		// Actually: Sign(-5.0f) = -1 (int), then Sign(-1 int) = -1
+		var inner = new SignResolver(
+			new VariantResolver(new Variant128(-5.0f), typeof(float)));
+
+		var outer = new SignResolver(inner);
+
+		var context = new GraphContext();
+
+		outer.Resolve(context).AsInt().Should().Be(-1);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sign")]
+	public void Sign_resolver_throws_for_unsigned_type()
+	{
+#pragma warning disable CA1806
+		Action act = () => new SignResolver(
+			new VariantResolver(new Variant128(5U), typeof(uint)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sign")]
+	public void Sign_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new SignResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sign")]
+	public void Sign_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new SignResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/SinHResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/SinHResolverTests.cs
@@ -1,0 +1,128 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class SinHResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "SinH")]
+	public void SinH_resolver_float_value_type_is_float()
+	{
+		var resolver = new SinHResolver(
+			new VariantResolver(new Variant128(0.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "SinH")]
+	public void SinH_resolver_double_value_type_is_double()
+	{
+		var resolver = new SinHResolver(
+			new VariantResolver(new Variant128(0.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "SinH")]
+	public void SinH_resolver_int_promotes_to_double()
+	{
+		var resolver = new SinHResolver(
+			new VariantResolver(new Variant128(0), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "SinH")]
+	public void SinH_resolver_zero_returns_zero()
+	{
+		// SinH(0) = 0
+		var resolver = new SinHResolver(
+			new VariantResolver(new Variant128(0.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(0.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "SinH")]
+	public void SinH_resolver_one()
+	{
+		// SinH(1) ≈ 1.1752
+		var resolver = new SinHResolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(1.1752, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "SinH")]
+	public void SinH_resolver_is_odd_function()
+	{
+		// SinH(-1) = -SinH(1) ≈ -1.1752
+		var resolver = new SinHResolver(
+			new VariantResolver(new Variant128(-1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(-1.1752, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "SinH")]
+	public void SinH_resolver_float_computation()
+	{
+		var resolver = new SinHResolver(
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().BeApproximately(1.1752f, 0.01f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "SinH")]
+	public void SinH_resolver_throws_for_decimal_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new SinHResolver(
+			new VariantResolver(new Variant128(0.0m), typeof(decimal)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "SinH")]
+	public void SinH_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new SinHResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "SinH")]
+	public void SinH_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new SinHResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/SinResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/SinResolverTests.cs
@@ -1,0 +1,141 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class SinResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Sin")]
+	public void Sin_resolver_float_value_type_is_float()
+	{
+		var resolver = new SinResolver(
+			new VariantResolver(new Variant128(0.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sin")]
+	public void Sin_resolver_double_value_type_is_double()
+	{
+		var resolver = new SinResolver(
+			new VariantResolver(new Variant128(0.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sin")]
+	public void Sin_resolver_int_promotes_to_double()
+	{
+		var resolver = new SinResolver(
+			new VariantResolver(new Variant128(0), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sin")]
+	public void Sin_resolver_zero_returns_zero()
+	{
+		var resolver = new SinResolver(
+			new VariantResolver(new Variant128(0.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().BeApproximately(0.0f, 0.001f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sin")]
+	public void Sin_resolver_pi_over_2_returns_one()
+	{
+		var resolver = new SinResolver(
+			new VariantResolver(new Variant128(Math.PI / 2.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(1.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sin")]
+	public void Sin_resolver_pi_returns_zero()
+	{
+		var resolver = new SinResolver(
+			new VariantResolver(new Variant128(Math.PI), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(0.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sin")]
+	public void Sin_resolver_float_pi_over_6()
+	{
+		// Sin(π/6) = 0.5
+		var resolver = new SinResolver(
+			new VariantResolver(new Variant128(MathF.PI / 6.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().BeApproximately(0.5f, 0.001f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sin")]
+	public void Sin_resolver_supports_nesting()
+	{
+		// Sin(Sin(π/2)) = Sin(1.0) ≈ 0.8414
+		var inner = new SinResolver(
+			new VariantResolver(new Variant128(Math.PI / 2.0), typeof(double)));
+
+		var outer = new SinResolver(inner);
+
+		var context = new GraphContext();
+
+		outer.Resolve(context).AsDouble().Should().BeApproximately(0.8414, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sin")]
+	public void Sin_resolver_throws_for_decimal_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new SinResolver(
+			new VariantResolver(new Variant128(0.0m), typeof(decimal)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sin")]
+	public void Sin_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new SinResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sin")]
+	public void Sin_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new SinResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/SqrtResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/SqrtResolverTests.cs
@@ -1,0 +1,164 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class SqrtResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Sqrt")]
+	public void Sqrt_resolver_float_value_type_is_float()
+	{
+		var resolver = new SqrtResolver(
+			new VariantResolver(new Variant128(4.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sqrt")]
+	public void Sqrt_resolver_double_value_type_is_double()
+	{
+		var resolver = new SqrtResolver(
+			new VariantResolver(new Variant128(4.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sqrt")]
+	public void Sqrt_resolver_int_promotes_to_double()
+	{
+		var resolver = new SqrtResolver(
+			new VariantResolver(new Variant128(4), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sqrt")]
+	public void Sqrt_resolver_computes_float_sqrt()
+	{
+		var resolver = new SqrtResolver(
+			new VariantResolver(new Variant128(9.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(3.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sqrt")]
+	public void Sqrt_resolver_computes_double_sqrt()
+	{
+		var resolver = new SqrtResolver(
+			new VariantResolver(new Variant128(25.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(5.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sqrt")]
+	public void Sqrt_resolver_computes_int_sqrt_as_double()
+	{
+		var resolver = new SqrtResolver(
+			new VariantResolver(new Variant128(16), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(4.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sqrt")]
+	public void Sqrt_resolver_irrational_result()
+	{
+		var resolver = new SqrtResolver(
+			new VariantResolver(new Variant128(2.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(1.41421356, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sqrt")]
+	public void Sqrt_resolver_zero_returns_zero()
+	{
+		var resolver = new SqrtResolver(
+			new VariantResolver(new Variant128(0.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(0.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sqrt")]
+	public void Sqrt_resolver_one_returns_one()
+	{
+		var resolver = new SqrtResolver(
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(1.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sqrt")]
+	public void Sqrt_resolver_supports_nesting()
+	{
+		// Sqrt(Sqrt(256)) = Sqrt(16) = 4
+		var inner = new SqrtResolver(
+			new VariantResolver(new Variant128(256.0), typeof(double)));
+
+		var outer = new SqrtResolver(inner);
+
+		var context = new GraphContext();
+
+		outer.Resolve(context).AsDouble().Should().Be(4.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sqrt")]
+	public void Sqrt_resolver_throws_for_decimal_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new SqrtResolver(
+			new VariantResolver(new Variant128(4.0m), typeof(decimal)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sqrt")]
+	public void Sqrt_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new SqrtResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Sqrt")]
+	public void Sqrt_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new SqrtResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/SubtractResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/SubtractResolverTests.cs
@@ -9,8 +9,6 @@ namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
 
 public class SubtractResolverTests
 {
-	// --- Value Type ---
-
 	[Fact]
 	[Trait("Resolver", "Subtract")]
 	public void Subtract_resolver_int_minus_int_value_type_is_int()
@@ -43,8 +41,6 @@ public class SubtractResolverTests
 
 		resolver.ValueType.Should().Be(typeof(Vector3));
 	}
-
-	// --- Arithmetic ---
 
 	[Fact]
 	[Trait("Resolver", "Subtract")]
@@ -138,8 +134,6 @@ public class SubtractResolverTests
 		resolver.Resolve(context).AsInt().Should().Be(30);
 	}
 
-	// --- Negative result ---
-
 	[Fact]
 	[Trait("Resolver", "Subtract")]
 	public void Subtract_resolver_handles_negative_result()
@@ -165,8 +159,6 @@ public class SubtractResolverTests
 
 		resolver.Resolve(context).AsInt().Should().Be(42);
 	}
-
-	// --- Vectors ---
 
 	[Fact]
 	[Trait("Resolver", "Subtract")]
@@ -223,8 +215,6 @@ public class SubtractResolverTests
 		resolver.Resolve(context).AsQuaternion().Should().Be(left - right);
 	}
 
-	// --- Nesting ---
-
 	[Fact]
 	[Trait("Resolver", "Subtract")]
 	public void Subtract_resolver_supports_nesting()
@@ -242,8 +232,6 @@ public class SubtractResolverTests
 
 		outer.Resolve(context).AsInt().Should().Be(50);
 	}
-
-	// --- Invalid types ---
 
 	[Fact]
 	[Trait("Resolver", "Subtract")]

--- a/Forge.Tests/Statescript/Resolvers/SubtractResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/SubtractResolverTests.cs
@@ -1,0 +1,273 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class SubtractResolverTests
+{
+	// --- Value Type ---
+
+	[Fact]
+	[Trait("Resolver", "Subtract")]
+	public void Subtract_resolver_int_minus_int_value_type_is_int()
+	{
+		var resolver = new SubtractResolver(
+			new VariantResolver(new Variant128(5), typeof(int)),
+			new VariantResolver(new Variant128(3), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(int));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Subtract")]
+	public void Subtract_resolver_int_minus_float_promotes_to_float()
+	{
+		var resolver = new SubtractResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(2.5f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Subtract")]
+	public void Subtract_resolver_vector3_minus_vector3_value_type_is_vector3()
+	{
+		var resolver = new SubtractResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)),
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+
+		resolver.ValueType.Should().Be(typeof(Vector3));
+	}
+
+	// --- Arithmetic ---
+
+	[Fact]
+	[Trait("Resolver", "Subtract")]
+	public void Subtract_resolver_subtracts_two_ints()
+	{
+		var resolver = new SubtractResolver(
+			new VariantResolver(new Variant128(30), typeof(int)),
+			new VariantResolver(new Variant128(10), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(20);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Subtract")]
+	public void Subtract_resolver_subtracts_two_doubles()
+	{
+		var resolver = new SubtractResolver(
+			new VariantResolver(new Variant128(10.5), typeof(double)),
+			new VariantResolver(new Variant128(3.5), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(7.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Subtract")]
+	public void Subtract_resolver_subtracts_two_floats()
+	{
+		var resolver = new SubtractResolver(
+			new VariantResolver(new Variant128(5.0f), typeof(float)),
+			new VariantResolver(new Variant128(2.5f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(2.5f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Subtract")]
+	public void Subtract_resolver_subtracts_two_longs()
+	{
+		var resolver = new SubtractResolver(
+			new VariantResolver(new Variant128(300L), typeof(long)),
+			new VariantResolver(new Variant128(100L), typeof(long)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsLong().Should().Be(200L);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Subtract")]
+	public void Subtract_resolver_subtracts_two_decimals()
+	{
+		var resolver = new SubtractResolver(
+			new VariantResolver(new Variant128(5.5m), typeof(decimal)),
+			new VariantResolver(new Variant128(2.2m), typeof(decimal)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDecimal().Should().Be(3.3m);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Subtract")]
+	public void Subtract_resolver_subtracts_int_and_float()
+	{
+		var resolver = new SubtractResolver(
+			new VariantResolver(new Variant128(10), typeof(int)),
+			new VariantResolver(new Variant128(2.5f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(7.5f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Subtract")]
+	public void Subtract_resolver_subtracts_byte_and_short()
+	{
+		var resolver = new SubtractResolver(
+			new VariantResolver(new Variant128((byte)50), typeof(byte)),
+			new VariantResolver(new Variant128((short)20), typeof(short)));
+
+		var context = new GraphContext();
+
+		// byte - short promotes to int
+		resolver.Resolve(context).AsInt().Should().Be(30);
+	}
+
+	// --- Negative result ---
+
+	[Fact]
+	[Trait("Resolver", "Subtract")]
+	public void Subtract_resolver_handles_negative_result()
+	{
+		var resolver = new SubtractResolver(
+			new VariantResolver(new Variant128(3), typeof(int)),
+			new VariantResolver(new Variant128(10), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(-7);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Subtract")]
+	public void Subtract_resolver_subtracting_zero_returns_same_value()
+	{
+		var resolver = new SubtractResolver(
+			new VariantResolver(new Variant128(42), typeof(int)),
+			new VariantResolver(new Variant128(0), typeof(int)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsInt().Should().Be(42);
+	}
+
+	// --- Vectors ---
+
+	[Fact]
+	[Trait("Resolver", "Subtract")]
+	public void Subtract_resolver_subtracts_two_vector2()
+	{
+		var resolver = new SubtractResolver(
+			new VariantResolver(new Variant128(new Vector2(5, 7)), typeof(Vector2)),
+			new VariantResolver(new Variant128(new Vector2(2, 3)), typeof(Vector2)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector2().Should().Be(new Vector2(3, 4));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Subtract")]
+	public void Subtract_resolver_subtracts_two_vector3()
+	{
+		var resolver = new SubtractResolver(
+			new VariantResolver(new Variant128(new Vector3(10, 20, 30)), typeof(Vector3)),
+			new VariantResolver(new Variant128(new Vector3(1, 2, 3)), typeof(Vector3)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector3().Should().Be(new Vector3(9, 18, 27));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Subtract")]
+	public void Subtract_resolver_subtracts_two_vector4()
+	{
+		var resolver = new SubtractResolver(
+			new VariantResolver(new Variant128(new Vector4(10, 20, 30, 40)), typeof(Vector4)),
+			new VariantResolver(new Variant128(new Vector4(1, 2, 3, 4)), typeof(Vector4)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsVector4().Should().Be(new Vector4(9, 18, 27, 36));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Subtract")]
+	public void Subtract_resolver_subtracts_two_quaternions()
+	{
+		var left = new Quaternion(5, 6, 7, 8);
+		var right = new Quaternion(1, 2, 3, 4);
+
+		var resolver = new SubtractResolver(
+			new VariantResolver(new Variant128(left), typeof(Quaternion)),
+			new VariantResolver(new Variant128(right), typeof(Quaternion)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsQuaternion().Should().Be(left - right);
+	}
+
+	// --- Nesting ---
+
+	[Fact]
+	[Trait("Resolver", "Subtract")]
+	public void Subtract_resolver_supports_nesting()
+	{
+		// (100 - 30) - 20 = 50
+		var inner = new SubtractResolver(
+			new VariantResolver(new Variant128(100), typeof(int)),
+			new VariantResolver(new Variant128(30), typeof(int)));
+
+		var outer = new SubtractResolver(
+			inner,
+			new VariantResolver(new Variant128(20), typeof(int)));
+
+		var context = new GraphContext();
+
+		outer.Resolve(context).AsInt().Should().Be(50);
+	}
+
+	// --- Invalid types ---
+
+	[Fact]
+	[Trait("Resolver", "Subtract")]
+	public void Subtract_resolver_throws_for_bool_operands()
+	{
+#pragma warning disable CA1806
+		Action act = () => new SubtractResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)),
+			new VariantResolver(new Variant128(false), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Subtract")]
+	public void Subtract_resolver_throws_for_mismatched_vector_types()
+	{
+#pragma warning disable CA1806
+		Action act = () => new SubtractResolver(
+			new VariantResolver(new Variant128(Vector2.One), typeof(Vector2)),
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/TanHResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/TanHResolverTests.cs
@@ -1,0 +1,141 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class TanHResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "TanH")]
+	public void TanH_resolver_float_value_type_is_float()
+	{
+		var resolver = new TanHResolver(
+			new VariantResolver(new Variant128(0.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "TanH")]
+	public void TanH_resolver_double_value_type_is_double()
+	{
+		var resolver = new TanHResolver(
+			new VariantResolver(new Variant128(0.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "TanH")]
+	public void TanH_resolver_int_promotes_to_double()
+	{
+		var resolver = new TanHResolver(
+			new VariantResolver(new Variant128(0), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "TanH")]
+	public void TanH_resolver_zero_returns_zero()
+	{
+		// TanH(0) = 0
+		var resolver = new TanHResolver(
+			new VariantResolver(new Variant128(0.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(0.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "TanH")]
+	public void TanH_resolver_one()
+	{
+		// TanH(1) ≈ 0.7616
+		var resolver = new TanHResolver(
+			new VariantResolver(new Variant128(1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(0.7616, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "TanH")]
+	public void TanH_resolver_large_value_approaches_one()
+	{
+		// TanH(10) → ≈ 1.0
+		var resolver = new TanHResolver(
+			new VariantResolver(new Variant128(10.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(1.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "TanH")]
+	public void TanH_resolver_is_odd_function()
+	{
+		// TanH(-1) = -TanH(1) ≈ -0.7616
+		var resolver = new TanHResolver(
+			new VariantResolver(new Variant128(-1.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(-0.7616, 0.001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "TanH")]
+	public void TanH_resolver_float_computation()
+	{
+		var resolver = new TanHResolver(
+			new VariantResolver(new Variant128(1.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().BeApproximately(0.7616f, 0.01f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "TanH")]
+	public void TanH_resolver_throws_for_decimal_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new TanHResolver(
+			new VariantResolver(new Variant128(0.0m), typeof(decimal)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "TanH")]
+	public void TanH_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new TanHResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "TanH")]
+	public void TanH_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new TanHResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/TanResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/TanResolverTests.cs
@@ -1,0 +1,143 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class TanResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Tan")]
+	public void Tan_resolver_float_value_type_is_float()
+	{
+		var resolver = new TanResolver(
+			new VariantResolver(new Variant128(0.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Tan")]
+	public void Tan_resolver_double_value_type_is_double()
+	{
+		var resolver = new TanResolver(
+			new VariantResolver(new Variant128(0.0), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Tan")]
+	public void Tan_resolver_int_promotes_to_double()
+	{
+		var resolver = new TanResolver(
+			new VariantResolver(new Variant128(0), typeof(int)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Tan")]
+	public void Tan_resolver_zero_returns_zero()
+	{
+		var resolver = new TanResolver(
+			new VariantResolver(new Variant128(0.0f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().BeApproximately(0.0f, 0.001f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Tan")]
+	public void Tan_resolver_pi_over_4_returns_one()
+	{
+		// Tan(π/4) = 1.0
+		var resolver = new TanResolver(
+			new VariantResolver(new Variant128(Math.PI / 4.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(1.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Tan")]
+	public void Tan_resolver_pi_returns_zero()
+	{
+		var resolver = new TanResolver(
+			new VariantResolver(new Variant128(Math.PI), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(0.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Tan")]
+	public void Tan_resolver_negative_pi_over_4()
+	{
+		// Tan(-π/4) = -1.0
+		var resolver = new TanResolver(
+			new VariantResolver(new Variant128(-Math.PI / 4.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().BeApproximately(-1.0, 0.0001);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Tan")]
+	public void Tan_resolver_supports_nesting()
+	{
+		// Tan(Tan(0.5)) — just verify no crash and reasonable value
+		var inner = new TanResolver(
+			new VariantResolver(new Variant128(0.5), typeof(double)));
+
+		var outer = new TanResolver(inner);
+
+		var context = new GraphContext();
+
+		// Tan(0.5) ≈ 0.5463, Tan(0.5463) ≈ 0.6108
+		outer.Resolve(context).AsDouble().Should().BeApproximately(0.6108, 0.01);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Tan")]
+	public void Tan_resolver_throws_for_decimal_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new TanResolver(
+			new VariantResolver(new Variant128(0.0m), typeof(decimal)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Tan")]
+	public void Tan_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new TanResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Tan")]
+	public void Tan_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new TanResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/TruncateResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/TruncateResolverTests.cs
@@ -1,0 +1,205 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class TruncateResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Truncate")]
+	public void Truncate_resolver_float_value_type_is_float()
+	{
+		var resolver = new TruncateResolver(
+			new VariantResolver(new Variant128(2.7f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(float));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Truncate")]
+	public void Truncate_resolver_double_value_type_is_double()
+	{
+		var resolver = new TruncateResolver(
+			new VariantResolver(new Variant128(2.7), typeof(double)));
+
+		resolver.ValueType.Should().Be(typeof(double));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Truncate")]
+	public void Truncate_resolver_decimal_value_type_is_decimal()
+	{
+		var resolver = new TruncateResolver(
+			new VariantResolver(new Variant128(2.7m), typeof(decimal)));
+
+		resolver.ValueType.Should().Be(typeof(decimal));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Truncate")]
+	public void Truncate_resolver_positive_float()
+	{
+		var resolver = new TruncateResolver(
+			new VariantResolver(new Variant128(2.7f), typeof(float)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsFloat().Should().Be(2.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Truncate")]
+	public void Truncate_resolver_negative_float_rounds_toward_zero()
+	{
+		var resolver = new TruncateResolver(
+			new VariantResolver(new Variant128(-2.7f), typeof(float)));
+
+		var context = new GraphContext();
+
+		// Truncate rounds toward zero: -2.7 → -2, not -3
+		resolver.Resolve(context).AsFloat().Should().Be(-2.0f);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Truncate")]
+	public void Truncate_resolver_positive_double()
+	{
+		var resolver = new TruncateResolver(
+			new VariantResolver(new Variant128(3.99), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(3.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Truncate")]
+	public void Truncate_resolver_negative_double_rounds_toward_zero()
+	{
+		var resolver = new TruncateResolver(
+			new VariantResolver(new Variant128(-3.99), typeof(double)));
+
+		var context = new GraphContext();
+
+		// Truncate rounds toward zero: -3.99 → -3, not -4
+		resolver.Resolve(context).AsDouble().Should().Be(-3.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Truncate")]
+	public void Truncate_resolver_positive_decimal()
+	{
+		var resolver = new TruncateResolver(
+			new VariantResolver(new Variant128(5.9m), typeof(decimal)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDecimal().Should().Be(5.0m);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Truncate")]
+	public void Truncate_resolver_negative_decimal_rounds_toward_zero()
+	{
+		var resolver = new TruncateResolver(
+			new VariantResolver(new Variant128(-5.9m), typeof(decimal)));
+
+		var context = new GraphContext();
+
+		// Truncate rounds toward zero: -5.9 → -5, not -6
+		resolver.Resolve(context).AsDecimal().Should().Be(-5.0m);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Truncate")]
+	public void Truncate_resolver_whole_number_returns_same()
+	{
+		var resolver = new TruncateResolver(
+			new VariantResolver(new Variant128(5.0), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(5.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Truncate")]
+	public void Truncate_resolver_small_positive_fraction()
+	{
+		var resolver = new TruncateResolver(
+			new VariantResolver(new Variant128(0.9), typeof(double)));
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(0.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Truncate")]
+	public void Truncate_resolver_small_negative_fraction()
+	{
+		var resolver = new TruncateResolver(
+			new VariantResolver(new Variant128(-0.9), typeof(double)));
+
+		var context = new GraphContext();
+
+		// Truncate rounds toward zero: -0.9 → 0, not -1
+		resolver.Resolve(context).AsDouble().Should().Be(0.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Truncate")]
+	public void Truncate_resolver_supports_nesting()
+	{
+		// Truncate(2.7 + 1.1) = Truncate(3.8) = 3.0
+		var sum = new AddResolver(
+			new VariantResolver(new Variant128(2.7), typeof(double)),
+			new VariantResolver(new Variant128(1.1), typeof(double)));
+
+		var resolver = new TruncateResolver(sum);
+
+		var context = new GraphContext();
+
+		resolver.Resolve(context).AsDouble().Should().Be(3.0);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Truncate")]
+	public void Truncate_resolver_throws_for_int_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new TruncateResolver(
+			new VariantResolver(new Variant128(5), typeof(int)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Truncate")]
+	public void Truncate_resolver_throws_for_vector_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new TruncateResolver(
+			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Truncate")]
+	public void Truncate_resolver_throws_for_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new TruncateResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge/Core/IRandom.cs
+++ b/Forge/Core/IRandom.cs
@@ -17,7 +17,8 @@ public interface IRandom
 	/// Returns a non-negative random integer that is less than the specified maximum.
 	/// </summary>
 	/// <param name="maxValue">Exclusive max value.</param>
-	/// <returns>An integer in the range [0, <paramref name="maxValue"/>), or 0 if <paramref name="maxValue"/> is less than or equal to 0.</returns>
+	/// <returns>An integer in the range [0, <paramref name="maxValue"/>), or 0 if <paramref name="maxValue"/> is less
+	/// than or equal to 0.</returns>
 	int NextInt(int maxValue);
 
 	/// <summary>
@@ -25,7 +26,8 @@ public interface IRandom
 	/// </summary>
 	/// <param name="minValue">Inclusive min value.</param>
 	/// <param name="maxValue">Exclusive max value.</param>
-	/// <returns>An integer in the range [<paramref name="minValue"/>, <paramref name="maxValue"/>), or <paramref name="minValue"/> if the range is invalid.</returns>
+	/// <returns>An integer in the range [<paramref name="minValue"/>, <paramref name="maxValue"/>), or
+	/// <paramref name="minValue"/> if the range is invalid.</returns>
 	int NextInt(int minValue, int maxValue);
 
 	/// <summary>
@@ -50,7 +52,8 @@ public interface IRandom
 	/// Returns a non-negative random integer that is less than the specified maximum.
 	/// </summary>
 	/// <param name="maxValue">Exclusive max value.</param>
-	/// <returns>A 64-bit integer in the range [0, <paramref name="maxValue"/>), or 0 if <paramref name="maxValue"/> is less than or equal to 0.</returns>
+	/// <returns>A 64-bit integer in the range [0, <paramref name="maxValue"/>), or 0 if <paramref name="maxValue"/> is
+	/// less than or equal to 0.</returns>
 	long NextInt64(long maxValue);
 
 	/// <summary>
@@ -58,7 +61,8 @@ public interface IRandom
 	/// </summary>
 	/// <param name="minValue">Inclusive min value.</param>
 	/// <param name="maxValue">Exclusive max value.</param>
-	/// <returns>A 64-bit integer in the range [<paramref name="minValue"/>, <paramref name="maxValue"/>), or <paramref name="minValue"/> if the range is invalid.</returns>
+	/// <returns>A 64-bit integer in the range [<paramref name="minValue"/>, <paramref name="maxValue"/>), or
+	/// <paramref name="minValue"/> if the range is invalid.</returns>
 	long NextInt64(long minValue, long maxValue);
 
 	/// <summary>

--- a/Forge/Statescript/Properties/ACosHResolver.cs
+++ b/Forge/Statescript/Properties/ACosHResolver.cs
@@ -1,0 +1,39 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the inverse hyperbolic cosine of a single <see cref="IPropertyResolver"/> operand. Supports
+/// <see langword="float"/> and <see langword="double"/> types. Integer operand types are promoted to
+/// <see langword="double"/>. Decimal, vector, and quaternion types are not supported.
+/// </summary>
+/// <param name="operand">The resolver for the operand (value ≥ 1).</param>
+public class ACosHResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointPromotedUnaryResultType(
+		nameof(ACosHResolver),
+		operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(MathF.Acosh(value.AsFloat()));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(Math.Acosh(MathTypeUtils.ResolveAsDouble(_operand.ValueType, value)));
+		}
+
+		throw new InvalidOperationException(
+			$"ACosHResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/ACosResolver.cs
+++ b/Forge/Statescript/Properties/ACosResolver.cs
@@ -1,0 +1,39 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the arc cosine (inverse cosine) of a single <see cref="IPropertyResolver"/> operand, returning the angle
+/// in radians. Supports <see langword="float"/> and <see langword="double"/> types. Integer operand types are promoted
+/// to <see langword="double"/>. Decimal, vector, and quaternion types are not supported.
+/// </summary>
+/// <param name="operand">The resolver for the operand (value in the range [-1, 1]).</param>
+public class ACosResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointPromotedUnaryResultType(
+		nameof(ACosResolver),
+		operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(MathF.Acos(value.AsFloat()));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(Math.Acos(MathTypeUtils.ResolveAsDouble(_operand.ValueType, value)));
+		}
+
+		throw new InvalidOperationException(
+			$"ACosResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/ASinHResolver.cs
+++ b/Forge/Statescript/Properties/ASinHResolver.cs
@@ -1,0 +1,39 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the inverse hyperbolic sine of a single <see cref="IPropertyResolver"/> operand. Supports
+/// <see langword="float"/> and <see langword="double"/> types. Integer operand types are promoted to
+/// <see langword="double"/>. Decimal, vector, and quaternion types are not supported.
+/// </summary>
+/// <param name="operand">The resolver for the operand.</param>
+public class ASinHResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointPromotedUnaryResultType(
+		nameof(ASinHResolver),
+		operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(MathF.Asinh(value.AsFloat()));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(Math.Asinh(MathTypeUtils.ResolveAsDouble(_operand.ValueType, value)));
+		}
+
+		throw new InvalidOperationException(
+			$"ASinHResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/ASinResolver.cs
+++ b/Forge/Statescript/Properties/ASinResolver.cs
@@ -1,0 +1,39 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the arc sine (inverse sine) of a single <see cref="IPropertyResolver"/> operand, returning the angle in
+/// radians. Supports <see langword="float"/> and <see langword="double"/> types. Integer operand types are promoted to
+/// <see langword="double"/>. Decimal, vector, and quaternion types are not supported.
+/// </summary>
+/// <param name="operand">The resolver for the operand (value in the range [-1, 1]).</param>
+public class ASinResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointPromotedUnaryResultType(
+		nameof(ASinResolver),
+		operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(MathF.Asin(value.AsFloat()));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(Math.Asin(MathTypeUtils.ResolveAsDouble(_operand.ValueType, value)));
+		}
+
+		throw new InvalidOperationException(
+			$"ASinResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/ATan2Resolver.cs
+++ b/Forge/Statescript/Properties/ATan2Resolver.cs
@@ -1,0 +1,50 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the angle (in radians) whose tangent is the quotient of two <see cref="IPropertyResolver"/> operands.
+/// Computes <c>ATan2(y, x)</c>. Supports <see langword="float"/> and <see langword="double"/> types. Integer operand
+/// types are promoted to <see langword="double"/>. Decimal, vector, and quaternion types are not supported.
+/// </summary>
+/// <param name="y">The resolver for the y-coordinate operand.</param>
+/// <param name="x">The resolver for the x-coordinate operand.</param>
+public class ATan2Resolver(IPropertyResolver y, IPropertyResolver x) : IPropertyResolver
+{
+	private readonly IPropertyResolver _y = y;
+
+	private readonly IPropertyResolver _x = x;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointBinaryResultType(
+		nameof(ATan2Resolver),
+		y.ValueType,
+		x.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 yValue = _y.Resolve(graphContext);
+		Variant128 xValue = _x.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(
+				MathF.Atan2(
+					MathTypeUtils.ResolveAsFloat(_y.ValueType, yValue),
+					MathTypeUtils.ResolveAsFloat(_x.ValueType, xValue)));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(
+				Math.Atan2(
+					MathTypeUtils.ResolveAsDouble(_y.ValueType, yValue),
+					MathTypeUtils.ResolveAsDouble(_x.ValueType, xValue)));
+		}
+
+		throw new InvalidOperationException(
+			$"ATan2Resolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/ATanHResolver.cs
+++ b/Forge/Statescript/Properties/ATanHResolver.cs
@@ -1,0 +1,39 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the inverse hyperbolic tangent of a single <see cref="IPropertyResolver"/> operand. Supports
+/// <see langword="float"/> and <see langword="double"/> types. Integer operand types are promoted to
+/// <see langword="double"/>. Decimal, vector, and quaternion types are not supported.
+/// </summary>
+/// <param name="operand">The resolver for the operand (value in the range (-1, 1)).</param>
+public class ATanHResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointPromotedUnaryResultType(
+		nameof(ATanHResolver),
+		operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(MathF.Atanh(value.AsFloat()));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(Math.Atanh(MathTypeUtils.ResolveAsDouble(_operand.ValueType, value)));
+		}
+
+		throw new InvalidOperationException(
+			$"ATanHResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/ATanResolver.cs
+++ b/Forge/Statescript/Properties/ATanResolver.cs
@@ -1,0 +1,39 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the arc tangent (inverse tangent) of a single <see cref="IPropertyResolver"/> operand, returning the
+/// angle in radians. Supports <see langword="float"/> and <see langword="double"/> types. Integer operand types are
+/// promoted to <see langword="double"/>. Decimal, vector, and quaternion types are not supported.
+/// </summary>
+/// <param name="operand">The resolver for the operand.</param>
+public class ATanResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointPromotedUnaryResultType(
+		nameof(ATanResolver),
+		operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(MathF.Atan(value.AsFloat()));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(Math.Atan(MathTypeUtils.ResolveAsDouble(_operand.ValueType, value)));
+		}
+
+		throw new InvalidOperationException(
+			$"ATanResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/AbsResolver.cs
+++ b/Forge/Statescript/Properties/AbsResolver.cs
@@ -1,0 +1,76 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the absolute value of a single <see cref="IPropertyResolver"/> operand. Supports all signed numeric types
+/// in <see cref="Variant128"/>. Unsigned types, vector types, and quaternion types are not supported. Sub-int types
+/// are promoted to <see langword="int"/> following standard C# rules.
+/// </summary>
+/// <param name="operand">The resolver for the operand.</param>
+public class AbsResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = DetermineResultType(operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(int))
+		{
+			return new Variant128(Math.Abs(MathTypeUtils.ResolveAsInt(_operand.ValueType, value)));
+		}
+
+		if (resultType == typeof(long))
+		{
+			return new Variant128(Math.Abs(MathTypeUtils.ResolveAsLong(_operand.ValueType, value)));
+		}
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(Math.Abs(MathTypeUtils.ResolveAsFloat(_operand.ValueType, value)));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(Math.Abs(MathTypeUtils.ResolveAsDouble(_operand.ValueType, value)));
+		}
+
+		if (resultType == typeof(decimal))
+		{
+			return new Variant128(Math.Abs(MathTypeUtils.ResolveAsDecimal(_operand.ValueType, value)));
+		}
+
+		throw new InvalidOperationException(
+			$"AbsResolver encountered unexpected result type '{resultType}'.");
+	}
+
+	private static Type DetermineResultType(Type operandType)
+	{
+		if (IsUnsignedType(operandType))
+		{
+			throw new ArgumentException(
+				$"AbsResolver does not support unsigned type '{operandType}'. " +
+				"Absolute value is only meaningful for signed types.");
+		}
+
+		return MathTypeUtils.DetermineUnaryResultType(
+			nameof(AbsResolver),
+			operandType,
+			allowVectors: false,
+			allowQuaternions: false);
+	}
+
+	private static bool IsUnsignedType(Type type)
+	{
+		return type == typeof(byte)
+			|| type == typeof(ushort)
+			|| type == typeof(uint)
+			|| type == typeof(ulong);
+	}
+}

--- a/Forge/Statescript/Properties/AddResolver.cs
+++ b/Forge/Statescript/Properties/AddResolver.cs
@@ -1,0 +1,98 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the sum of two nested <see cref="IPropertyResolver"/> operands. Supports all numeric types in
+/// <see cref="Variant128"/> as well as <see cref="Vector2"/>, <see cref="Vector3"/>, <see cref="Vector4"/>, and
+/// <see cref="Quaternion"/>. When the two operands have different numeric types, standard numeric promotion rules
+/// apply (e.g., <see langword="int"/> + <see langword="float"/> → <see langword="float"/>). Vector and quaternion
+/// operands must match exactly.
+/// </summary>
+/// <remarks>
+/// <para>This resolver enables data-driven arithmetic expressions in graph properties without requiring custom node
+/// subclasses. Operand resolvers can be any <see cref="IPropertyResolver"/> implementation, including other
+/// <see cref="AddResolver"/> instances, enabling arbitrarily nested expressions.</para>
+/// </remarks>
+/// <param name="left">The resolver for the left operand.</param>
+/// <param name="right">The resolver for the right operand.</param>
+public class AddResolver(IPropertyResolver left, IPropertyResolver right) : IPropertyResolver
+{
+	private readonly IPropertyResolver _left = left;
+
+	private readonly IPropertyResolver _right = right;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineBinaryResultType(
+		nameof(AddResolver),
+		left.ValueType,
+		right.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 leftValue = _left.Resolve(graphContext);
+		Variant128 rightValue = _right.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(int))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsInt(_left.ValueType, leftValue)
+				+ MathTypeUtils.ResolveAsInt(_right.ValueType, rightValue));
+		}
+
+		if (resultType == typeof(long))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsLong(_left.ValueType, leftValue)
+				+ MathTypeUtils.ResolveAsLong(_right.ValueType, rightValue));
+		}
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsFloat(_left.ValueType, leftValue)
+				+ MathTypeUtils.ResolveAsFloat(_right.ValueType, rightValue));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsDouble(_left.ValueType, leftValue)
+				+ MathTypeUtils.ResolveAsDouble(_right.ValueType, rightValue));
+		}
+
+		if (resultType == typeof(decimal))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsDecimal(_left.ValueType, leftValue)
+				+ MathTypeUtils.ResolveAsDecimal(_right.ValueType, rightValue));
+		}
+
+		if (resultType == typeof(Vector2))
+		{
+			return new Variant128(leftValue.AsVector2() + rightValue.AsVector2());
+		}
+
+		if (resultType == typeof(Vector3))
+		{
+			return new Variant128(leftValue.AsVector3() + rightValue.AsVector3());
+		}
+
+		if (resultType == typeof(Vector4))
+		{
+			return new Variant128(leftValue.AsVector4() + rightValue.AsVector4());
+		}
+
+		if (resultType == typeof(Quaternion))
+		{
+			return new Variant128(leftValue.AsQuaternion() + rightValue.AsQuaternion());
+		}
+
+		throw new InvalidOperationException(
+			$"AddResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/CbrtResolver.cs
+++ b/Forge/Statescript/Properties/CbrtResolver.cs
@@ -1,0 +1,39 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the cube root of a single <see cref="IPropertyResolver"/> operand. Supports <see langword="float"/> and
+/// <see langword="double"/> types. Integer operand types are promoted to <see langword="double"/>. Decimal, vector,
+/// and quaternion types are not supported.
+/// </summary>
+/// <param name="operand">The resolver for the operand.</param>
+public class CbrtResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointPromotedUnaryResultType(
+		nameof(CbrtResolver),
+		operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(MathF.Cbrt(value.AsFloat()));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(Math.Cbrt(MathTypeUtils.ResolveAsDouble(_operand.ValueType, value)));
+		}
+
+		throw new InvalidOperationException(
+			$"CbrtResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/CeilResolver.cs
+++ b/Forge/Statescript/Properties/CeilResolver.cs
@@ -1,0 +1,43 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the smallest integer greater than or equal to the operand (ceiling). Supports <see langword="float"/>,
+/// <see langword="double"/>, and <see langword="decimal"/> types only. Integer, vector, and quaternion types are not
+/// supported.
+/// </summary>
+/// <param name="operand">The resolver for the operand.</param>
+public class CeilResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointUnaryResultType(
+		nameof(CeilResolver),
+		operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(MathF.Ceiling(value.AsFloat()));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(Math.Ceiling(value.AsDouble()));
+		}
+
+		if (resultType == typeof(decimal))
+		{
+			return new Variant128(Math.Ceiling(value.AsDecimal()));
+		}
+
+		throw new InvalidOperationException($"CeilResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/ClampResolver.cs
+++ b/Forge/Statescript/Properties/ClampResolver.cs
@@ -1,0 +1,84 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves a value clamped between a minimum and maximum bound using three nested <see cref="IPropertyResolver"/>
+/// operands. Supports all numeric types in <see cref="Variant128"/>. Vector and quaternion types are not supported.
+/// When operands have different numeric types, standard numeric promotion rules apply.
+/// </summary>
+/// <param name="value">The resolver for the value to clamp.</param>
+/// <param name="min">The resolver for the minimum bound.</param>
+/// <param name="max">The resolver for the maximum bound.</param>
+public class ClampResolver(IPropertyResolver value, IPropertyResolver min, IPropertyResolver max)
+	: IPropertyResolver
+{
+	private readonly IPropertyResolver _value = value;
+
+	private readonly IPropertyResolver _min = min;
+
+	private readonly IPropertyResolver _max = max;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineTernaryResultType(
+		nameof(ClampResolver),
+		value.ValueType,
+		min.ValueType,
+		max.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 valueToClamp = _value.Resolve(graphContext);
+		Variant128 minValue = _min.Resolve(graphContext);
+		Variant128 maxValue = _max.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(int))
+		{
+			return new Variant128(
+				Math.Clamp(
+					MathTypeUtils.ResolveAsInt(_value.ValueType, valueToClamp),
+					MathTypeUtils.ResolveAsInt(_min.ValueType, minValue),
+					MathTypeUtils.ResolveAsInt(_max.ValueType, maxValue)));
+		}
+
+		if (resultType == typeof(long))
+		{
+			return new Variant128(
+				Math.Clamp(
+					MathTypeUtils.ResolveAsLong(_value.ValueType, valueToClamp),
+					MathTypeUtils.ResolveAsLong(_min.ValueType, minValue),
+					MathTypeUtils.ResolveAsLong(_max.ValueType, maxValue)));
+		}
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(
+				Math.Clamp(
+					MathTypeUtils.ResolveAsFloat(_value.ValueType, valueToClamp),
+					MathTypeUtils.ResolveAsFloat(_min.ValueType, minValue),
+					MathTypeUtils.ResolveAsFloat(_max.ValueType, maxValue)));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(
+				Math.Clamp(
+					MathTypeUtils.ResolveAsDouble(_value.ValueType, valueToClamp),
+					MathTypeUtils.ResolveAsDouble(_min.ValueType, minValue),
+					MathTypeUtils.ResolveAsDouble(_max.ValueType, maxValue)));
+		}
+
+		if (resultType == typeof(decimal))
+		{
+			return new Variant128(
+				Math.Clamp(
+					MathTypeUtils.ResolveAsDecimal(_value.ValueType, valueToClamp),
+					MathTypeUtils.ResolveAsDecimal(_min.ValueType, minValue),
+					MathTypeUtils.ResolveAsDecimal(_max.ValueType, maxValue)));
+		}
+
+		throw new InvalidOperationException($"ClampResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/CopySignResolver.cs
+++ b/Forge/Statescript/Properties/CopySignResolver.cs
@@ -33,19 +33,33 @@ public class CopySignResolver(IPropertyResolver magnitude, IPropertyResolver sig
 		{
 			var mag = MathTypeUtils.ResolveAsFloat(_magnitude.ValueType, magnitudeValue);
 			var sgn = MathTypeUtils.ResolveAsFloat(_sign.ValueType, signValue);
-			var result = MathF.Abs(mag) * (sgn >= 0 ? 1.0f : -1.0f);
-			return new Variant128(result);
+			return new Variant128(CopySignFloat(mag, sgn));
 		}
 
 		if (resultType == typeof(double))
 		{
 			var mag = MathTypeUtils.ResolveAsDouble(_magnitude.ValueType, magnitudeValue);
 			var sgn = MathTypeUtils.ResolveAsDouble(_sign.ValueType, signValue);
-			var result = Math.Abs(mag) * (sgn >= 0 ? 1.0 : -1.0);
-			return new Variant128(result);
+			return new Variant128(CopySignDouble(mag, sgn));
 		}
 
 		throw new InvalidOperationException(
 			$"CopySignResolver encountered unexpected result type '{resultType}'.");
+	}
+
+	private static float CopySignFloat(float magnitude, float sign)
+	{
+		const int signMask = unchecked((int)0x80000000);
+		var magnitudeBits = BitConverter.SingleToInt32Bits(magnitude);
+		var signBits = BitConverter.SingleToInt32Bits(sign);
+		return BitConverter.Int32BitsToSingle((magnitudeBits & ~signMask) | (signBits & signMask));
+	}
+
+	private static double CopySignDouble(double magnitude, double sign)
+	{
+		const long signMask = unchecked((long)0x8000000000000000);
+		var magnitudeBits = BitConverter.DoubleToInt64Bits(magnitude);
+		var signBits = BitConverter.DoubleToInt64Bits(sign);
+		return BitConverter.Int64BitsToDouble((magnitudeBits & ~signMask) | (signBits & signMask));
 	}
 }

--- a/Forge/Statescript/Properties/CopySignResolver.cs
+++ b/Forge/Statescript/Properties/CopySignResolver.cs
@@ -1,0 +1,51 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves a value with the magnitude of the first operand and the sign of the second operand using two nested
+/// <see cref="IPropertyResolver"/> operands. Computes <c>CopySign(magnitude, sign)</c>. Supports
+/// <see langword="float"/> and <see langword="double"/> types. Integer operand types are promoted to
+/// <see langword="double"/>. Decimal, vector, and quaternion types are not supported.
+/// </summary>
+/// <param name="magnitude">The resolver for the magnitude operand.</param>
+/// <param name="sign">The resolver for the sign operand.</param>
+public class CopySignResolver(IPropertyResolver magnitude, IPropertyResolver sign) : IPropertyResolver
+{
+	private readonly IPropertyResolver _magnitude = magnitude;
+
+	private readonly IPropertyResolver _sign = sign;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointBinaryResultType(
+		nameof(CopySignResolver),
+		magnitude.ValueType,
+		sign.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 magnitudeValue = _magnitude.Resolve(graphContext);
+		Variant128 signValue = _sign.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			var mag = MathTypeUtils.ResolveAsFloat(_magnitude.ValueType, magnitudeValue);
+			var sgn = MathTypeUtils.ResolveAsFloat(_sign.ValueType, signValue);
+			var result = MathF.Abs(mag) * (sgn >= 0 ? 1.0f : -1.0f);
+			return new Variant128(result);
+		}
+
+		if (resultType == typeof(double))
+		{
+			var mag = MathTypeUtils.ResolveAsDouble(_magnitude.ValueType, magnitudeValue);
+			var sgn = MathTypeUtils.ResolveAsDouble(_sign.ValueType, signValue);
+			var result = Math.Abs(mag) * (sgn >= 0 ? 1.0 : -1.0);
+			return new Variant128(result);
+		}
+
+		throw new InvalidOperationException(
+			$"CopySignResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/CosHResolver.cs
+++ b/Forge/Statescript/Properties/CosHResolver.cs
@@ -1,0 +1,39 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the hyperbolic cosine of a single <see cref="IPropertyResolver"/> operand. Supports
+/// <see langword="float"/> and <see langword="double"/> types. Integer operand types are promoted to
+/// <see langword="double"/>. Decimal, vector, and quaternion types are not supported.
+/// </summary>
+/// <param name="operand">The resolver for the operand.</param>
+public class CosHResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointPromotedUnaryResultType(
+		nameof(CosHResolver),
+		operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(MathF.Cosh(value.AsFloat()));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(Math.Cosh(MathTypeUtils.ResolveAsDouble(_operand.ValueType, value)));
+		}
+
+		throw new InvalidOperationException(
+			$"CosHResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/CosResolver.cs
+++ b/Forge/Statescript/Properties/CosResolver.cs
@@ -1,0 +1,39 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the cosine of a single <see cref="IPropertyResolver"/> operand (in radians). Supports
+/// <see langword="float"/> and <see langword="double"/> types. Integer operand types are promoted to
+/// <see langword="double"/>. Decimal, vector, and quaternion types are not supported.
+/// </summary>
+/// <param name="operand">The resolver for the operand (angle in radians).</param>
+public class CosResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointPromotedUnaryResultType(
+		nameof(CosResolver),
+		operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(MathF.Cos(value.AsFloat()));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(Math.Cos(MathTypeUtils.ResolveAsDouble(_operand.ValueType, value)));
+		}
+
+		throw new InvalidOperationException(
+			$"CosResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/DegToRadResolver.cs
+++ b/Forge/Statescript/Properties/DegToRadResolver.cs
@@ -1,0 +1,40 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves a conversion from degrees to radians using a single <see cref="IPropertyResolver"/> operand. Computes
+/// <c>degrees * (π / 180)</c>. Supports <see langword="float"/> and <see langword="double"/> types. Integer operand
+/// types are promoted to <see langword="double"/>. Decimal, vector, and quaternion types are not supported.
+/// </summary>
+/// <param name="operand">The resolver for the operand (angle in degrees).</param>
+public class DegToRadResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointPromotedUnaryResultType(
+		nameof(DegToRadResolver),
+		operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(value.AsFloat() * (MathF.PI / 180.0f));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsDouble(_operand.ValueType, value) * (Math.PI / 180.0));
+		}
+
+		throw new InvalidOperationException(
+			$"DegToRadResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/DivideResolver.cs
+++ b/Forge/Statescript/Properties/DivideResolver.cs
@@ -1,0 +1,88 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the quotient of two nested <see cref="IPropertyResolver"/> operands. Supports all numeric types in
+/// <see cref="Variant128"/> as well as <see cref="Vector2"/>, <see cref="Vector3"/>, and <see cref="Vector4"/>
+/// (component-wise division). <see cref="Quaternion"/> is not supported. When the two operands have different numeric
+/// types, standard numeric promotion rules apply. Vector operands must match exactly.
+/// </summary>
+/// <param name="left">The resolver for the left (dividend) operand.</param>
+/// <param name="right">The resolver for the right (divisor) operand.</param>
+public class DivideResolver(IPropertyResolver left, IPropertyResolver right) : IPropertyResolver
+{
+	private readonly IPropertyResolver _left = left;
+
+	private readonly IPropertyResolver _right = right;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineBinaryResultType(
+		nameof(DivideResolver),
+		left.ValueType,
+		right.ValueType,
+		allowQuaternions: false);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 leftValue = _left.Resolve(graphContext);
+		Variant128 rightValue = _right.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(int))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsInt(_left.ValueType, leftValue)
+				/ MathTypeUtils.ResolveAsInt(_right.ValueType, rightValue));
+		}
+
+		if (resultType == typeof(long))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsLong(_left.ValueType, leftValue)
+				/ MathTypeUtils.ResolveAsLong(_right.ValueType, rightValue));
+		}
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsFloat(_left.ValueType, leftValue)
+				/ MathTypeUtils.ResolveAsFloat(_right.ValueType, rightValue));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsDouble(_left.ValueType, leftValue)
+				/ MathTypeUtils.ResolveAsDouble(_right.ValueType, rightValue));
+		}
+
+		if (resultType == typeof(decimal))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsDecimal(_left.ValueType, leftValue)
+				/ MathTypeUtils.ResolveAsDecimal(_right.ValueType, rightValue));
+		}
+
+		if (resultType == typeof(Vector2))
+		{
+			return new Variant128(leftValue.AsVector2() / rightValue.AsVector2());
+		}
+
+		if (resultType == typeof(Vector3))
+		{
+			return new Variant128(leftValue.AsVector3() / rightValue.AsVector3());
+		}
+
+		if (resultType == typeof(Vector4))
+		{
+			return new Variant128(leftValue.AsVector4() / rightValue.AsVector4());
+		}
+
+		throw new InvalidOperationException(
+			$"DivideResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/EResolver.cs
+++ b/Forge/Statescript/Properties/EResolver.cs
@@ -1,0 +1,37 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the mathematical constant e (Euler's number). Returns <see langword="double"/> by default, or
+/// <see langword="float"/> if explicitly requested. This avoids magic numbers and communicates intent clearly.
+/// </summary>
+/// <param name="valueType">The desired output type. Must be <see langword="float"/> or <see langword="double"/>.
+/// Defaults to <see langword="double"/> if not specified.</param>
+public class EResolver(Type? valueType = null) : IPropertyResolver
+{
+	/// <inheritdoc/>
+	public Type ValueType { get; } = ValidateType(valueType ?? typeof(double));
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		if (ValueType == typeof(float))
+		{
+			return new Variant128(MathF.E);
+		}
+
+		return new Variant128(Math.E);
+	}
+
+	private static Type ValidateType(Type type)
+	{
+		if (type != typeof(float) && type != typeof(double))
+		{
+			throw new ArgumentException(
+				$"EResolver only supports float and double output types. Got '{type}'.");
+		}
+
+		return type;
+	}
+}

--- a/Forge/Statescript/Properties/ExpResolver.cs
+++ b/Forge/Statescript/Properties/ExpResolver.cs
@@ -1,0 +1,39 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves <c>e</c> raised to the specified power (<c>e^x</c>) using a single <see cref="IPropertyResolver"/>
+/// operand. Supports <see langword="float"/> and <see langword="double"/> types. Integer operand types are promoted to
+/// <see langword="double"/>. Decimal, vector, and quaternion types are not supported.
+/// </summary>
+/// <param name="operand">The resolver for the exponent operand.</param>
+public class ExpResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointPromotedUnaryResultType(
+		nameof(ExpResolver),
+		operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(MathF.Exp(value.AsFloat()));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(Math.Exp(MathTypeUtils.ResolveAsDouble(_operand.ValueType, value)));
+		}
+
+		throw new InvalidOperationException(
+			$"ExpResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/FloorResolver.cs
+++ b/Forge/Statescript/Properties/FloorResolver.cs
@@ -1,0 +1,43 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the largest integer less than or equal to the operand (floor). Supports <see langword="float"/>,
+/// <see langword="double"/>, and <see langword="decimal"/> types only. Integer, vector, and quaternion types are not
+/// supported.
+/// </summary>
+/// <param name="operand">The resolver for the operand.</param>
+public class FloorResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointUnaryResultType(
+		nameof(FloorResolver),
+		operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(MathF.Floor(value.AsFloat()));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(Math.Floor(value.AsDouble()));
+		}
+
+		if (resultType == typeof(decimal))
+		{
+			return new Variant128(Math.Floor(value.AsDecimal()));
+		}
+
+		throw new InvalidOperationException($"FloorResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/LerpResolver.cs
+++ b/Forge/Statescript/Properties/LerpResolver.cs
@@ -1,0 +1,120 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves a linear interpolation between two values using three nested <see cref="IPropertyResolver"/> operands.
+/// Computes <c>a + (b - a) * t</c> for scalar types, or uses the built-in <c>Lerp</c> methods for
+/// <see cref="Vector2"/>, <see cref="Vector3"/>, <see cref="Vector4"/>, and <see cref="Quaternion"/>. Supports
+/// <see langword="float"/> and <see langword="double"/> scalar types. For vector and quaternion types, the <c>t</c>
+/// parameter must be <see langword="float"/>. Integer and decimal types are not supported.
+/// </summary>
+/// <param name="a">The resolver for the start value.</param>
+/// <param name="b">The resolver for the end value.</param>
+/// <param name="t">The resolver for the interpolation parameter (typically 0 to 1).</param>
+public class LerpResolver(IPropertyResolver a, IPropertyResolver b, IPropertyResolver t) : IPropertyResolver
+{
+	private readonly IPropertyResolver _a = a;
+
+	private readonly IPropertyResolver _b = b;
+
+	private readonly IPropertyResolver _t = t;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = DetermineLerpResultType(a.ValueType, b.ValueType, t.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 aValue = _a.Resolve(graphContext);
+		Variant128 bValue = _b.Resolve(graphContext);
+		Variant128 tValue = _t.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			var floatA = MathTypeUtils.ResolveAsFloat(_a.ValueType, aValue);
+			var floatB = MathTypeUtils.ResolveAsFloat(_b.ValueType, bValue);
+			var floatT = MathTypeUtils.ResolveAsFloat(_t.ValueType, tValue);
+			return new Variant128(floatA + ((floatB - floatA) * floatT));
+		}
+
+		if (resultType == typeof(double))
+		{
+			var doubleA = MathTypeUtils.ResolveAsDouble(_a.ValueType, aValue);
+			var doubleB = MathTypeUtils.ResolveAsDouble(_b.ValueType, bValue);
+			var doubleT = MathTypeUtils.ResolveAsDouble(_t.ValueType, tValue);
+			return new Variant128(doubleA + ((doubleB - doubleA) * doubleT));
+		}
+
+		if (resultType == typeof(Vector2))
+		{
+			return new Variant128(
+				Vector2.Lerp(aValue.AsVector2(), bValue.AsVector2(), tValue.AsFloat()));
+		}
+
+		if (resultType == typeof(Vector3))
+		{
+			return new Variant128(
+				Vector3.Lerp(aValue.AsVector3(), bValue.AsVector3(), tValue.AsFloat()));
+		}
+
+		if (resultType == typeof(Vector4))
+		{
+			return new Variant128(
+				Vector4.Lerp(aValue.AsVector4(), bValue.AsVector4(), tValue.AsFloat()));
+		}
+
+		if (resultType == typeof(Quaternion))
+		{
+			return new Variant128(
+				Quaternion.Lerp(aValue.AsQuaternion(), bValue.AsQuaternion(), tValue.AsFloat()));
+		}
+
+		throw new InvalidOperationException($"LerpResolver encountered unexpected result type '{resultType}'.");
+	}
+
+	private static Type DetermineLerpResultType(Type aType, Type bType, Type tType)
+	{
+		if (MathTypeUtils.IsVectorOrQuaternionType(aType)
+			|| MathTypeUtils.IsVectorOrQuaternionType(bType))
+		{
+			if (aType != bType)
+			{
+				throw new ArgumentException(
+					$"LerpResolver requires matching types for 'a' and 'b'. Got '{aType}' and '{bType}'.");
+			}
+
+			if (tType != typeof(float))
+			{
+				throw new ArgumentException(
+					$"LerpResolver requires 't' to be float for vector/quaternion lerp. Got '{tType}'.");
+			}
+
+			return aType;
+		}
+
+		ValidateScalarOperandType(aType, "a");
+		ValidateScalarOperandType(bType, "b");
+		ValidateScalarOperandType(tType, "t");
+
+		if (aType == typeof(double) || bType == typeof(double) || tType == typeof(double))
+		{
+			return typeof(double);
+		}
+
+		return typeof(float);
+	}
+
+	private static void ValidateScalarOperandType(Type type, string paramName)
+	{
+		if (type != typeof(float) && type != typeof(double))
+		{
+			throw new ArgumentException(
+				"LerpResolver only supports float, double, Vector2, Vector3, Vector4, and Quaternion " +
+				$"operands. Parameter '{paramName}' has type '{type}'.");
+		}
+	}
+}

--- a/Forge/Statescript/Properties/Log10Resolver.cs
+++ b/Forge/Statescript/Properties/Log10Resolver.cs
@@ -1,0 +1,39 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the base-10 logarithm of a single <see cref="IPropertyResolver"/> operand. Supports
+/// <see langword="float"/> and <see langword="double"/> types. Integer operand types are promoted to
+/// <see langword="double"/>. Decimal, vector, and quaternion types are not supported.
+/// </summary>
+/// <param name="operand">The resolver for the operand (must be positive).</param>
+public class Log10Resolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointPromotedUnaryResultType(
+		nameof(Log10Resolver),
+		operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(MathF.Log10(value.AsFloat()));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(Math.Log10(MathTypeUtils.ResolveAsDouble(_operand.ValueType, value)));
+		}
+
+		throw new InvalidOperationException(
+			$"Log10Resolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/Log2Resolver.cs
+++ b/Forge/Statescript/Properties/Log2Resolver.cs
@@ -1,0 +1,42 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the base-2 logarithm of a single <see cref="IPropertyResolver"/> operand. Supports
+/// <see langword="float"/> and <see langword="double"/> types. Integer operand types are promoted to
+/// <see langword="double"/>. Decimal, vector, and quaternion types are not supported.
+/// </summary>
+/// <param name="operand">The resolver for the operand (must be positive).</param>
+public class Log2Resolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private static readonly double _log2E = Math.Log(2.0);
+
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointPromotedUnaryResultType(
+		nameof(Log2Resolver),
+		operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128((float)(MathF.Log(value.AsFloat()) / _log2E));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(
+				Math.Log(MathTypeUtils.ResolveAsDouble(_operand.ValueType, value)) / _log2E);
+		}
+
+		throw new InvalidOperationException(
+			$"Log2Resolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/Log2Resolver.cs
+++ b/Forge/Statescript/Properties/Log2Resolver.cs
@@ -10,7 +10,9 @@ namespace Gamesmiths.Forge.Statescript.Properties;
 /// <param name="operand">The resolver for the operand (must be positive).</param>
 public class Log2Resolver(IPropertyResolver operand) : IPropertyResolver
 {
-	private static readonly double _log2E = Math.Log(2.0);
+	private static readonly float _ln2F = MathF.Log(2.0f);
+
+	private static readonly double _ln2 = Math.Log(2.0);
 
 	private readonly IPropertyResolver _operand = operand;
 
@@ -27,13 +29,13 @@ public class Log2Resolver(IPropertyResolver operand) : IPropertyResolver
 
 		if (resultType == typeof(float))
 		{
-			return new Variant128((float)(MathF.Log(value.AsFloat()) / _log2E));
+			return new Variant128(MathF.Log(value.AsFloat()) / _ln2F);
 		}
 
 		if (resultType == typeof(double))
 		{
 			return new Variant128(
-				Math.Log(MathTypeUtils.ResolveAsDouble(_operand.ValueType, value)) / _log2E);
+				Math.Log(MathTypeUtils.ResolveAsDouble(_operand.ValueType, value)) / _ln2);
 		}
 
 		throw new InvalidOperationException(

--- a/Forge/Statescript/Properties/LogResolver.cs
+++ b/Forge/Statescript/Properties/LogResolver.cs
@@ -1,0 +1,39 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the natural logarithm (base <c>e</c>) of a single <see cref="IPropertyResolver"/> operand. Supports
+/// <see langword="float"/> and <see langword="double"/> types. Integer operand types are promoted to
+/// <see langword="double"/>. Decimal, vector, and quaternion types are not supported.
+/// </summary>
+/// <param name="operand">The resolver for the operand (must be positive).</param>
+public class LogResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointPromotedUnaryResultType(
+		nameof(LogResolver),
+		operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(MathF.Log(value.AsFloat()));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(Math.Log(MathTypeUtils.ResolveAsDouble(_operand.ValueType, value)));
+		}
+
+		throw new InvalidOperationException(
+			$"LogResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/MathTypeUtils.cs
+++ b/Forge/Statescript/Properties/MathTypeUtils.cs
@@ -1,0 +1,453 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Shared utility methods for math resolvers: type promotion, numeric conversion, and type classification.
+/// </summary>
+internal static class MathTypeUtils
+{
+	/// <summary>
+	/// Determines the result type for a binary operation between two operand types, applying standard
+	/// C# numeric promotion rules. Vector and quaternion types must match exactly.
+	/// </summary>
+	/// <param name="resolverName">The name of the resolver (for error messages).</param>
+	/// <param name="leftType">The type of the left operand.</param>
+	/// <param name="rightType">The type of the right operand.</param>
+	/// <param name="allowVectors">Whether vector and quaternion types are supported.</param>
+	/// <param name="allowQuaternions">Whether quaternion types are supported (only relevant if
+	/// <paramref name="allowVectors"/> is true).</param>
+	/// <returns>The promoted result type.</returns>
+	/// <exception cref="ArgumentException">Thrown when the type combination is unsupported.</exception>
+	internal static Type DetermineBinaryResultType(
+		string resolverName,
+		Type leftType,
+		Type rightType,
+		bool allowVectors = true,
+		bool allowQuaternions = true)
+	{
+		if (leftType == rightType)
+		{
+			if (IsVectorType(leftType) || (leftType == typeof(Quaternion)))
+			{
+				if (!allowVectors && IsVectorType(leftType))
+				{
+					throw new ArgumentException(
+						$"{resolverName} does not support operand type '{leftType}'.");
+				}
+
+				if (!allowQuaternions && leftType == typeof(Quaternion))
+				{
+					throw new ArgumentException(
+						$"{resolverName} does not support operand type '{leftType}'.");
+				}
+
+				return leftType;
+			}
+
+			if (!IsNumericType(leftType))
+			{
+				throw new ArgumentException(
+					$"{resolverName} does not support operand type '{leftType}'.");
+			}
+
+			return PromoteNumericTypes(leftType, rightType);
+		}
+
+		var leftIsVectorLike = IsVectorOrQuaternionType(leftType);
+		var rightIsVectorLike = IsVectorOrQuaternionType(rightType);
+
+		if (leftIsVectorLike || rightIsVectorLike)
+		{
+			throw new ArgumentException(
+				$"{resolverName} cannot mix vector/quaternion types. Left: '{leftType}', Right: '{rightType}'.");
+		}
+
+		if (!IsNumericType(leftType))
+		{
+			throw new ArgumentException(
+				$"{resolverName} does not support operand type '{leftType}'.");
+		}
+
+		if (!IsNumericType(rightType))
+		{
+			throw new ArgumentException(
+				$"{resolverName} does not support operand type '{rightType}'.");
+		}
+
+		return PromoteNumericTypes(leftType, rightType);
+	}
+
+	/// <summary>
+	/// Determines the result type for a unary operation on a single operand type.
+	/// </summary>
+	/// <param name="resolverName">The name of the resolver (for error messages).</param>
+	/// <param name="operandType">The type of the operand.</param>
+	/// <param name="allowVectors">Whether vector and quaternion types are supported.</param>
+	/// <param name="allowQuaternions">Whether quaternion types are supported (only relevant if
+	/// <paramref name="allowVectors"/> is true).</param>
+	/// <returns>The result type (promoted for sub-int numerics).</returns>
+	/// <exception cref="ArgumentException">Thrown when the type is unsupported.</exception>
+	internal static Type DetermineUnaryResultType(
+		string resolverName,
+		Type operandType,
+		bool allowVectors = true,
+		bool allowQuaternions = true)
+	{
+		if (IsVectorType(operandType))
+		{
+			if (!allowVectors)
+			{
+				throw new ArgumentException(
+					$"{resolverName} does not support operand type '{operandType}'.");
+			}
+
+			return operandType;
+		}
+
+		if (operandType == typeof(Quaternion))
+		{
+			if (!allowQuaternions)
+			{
+				throw new ArgumentException(
+					$"{resolverName} does not support operand type '{operandType}'.");
+			}
+
+			return operandType;
+		}
+
+		if (!IsNumericType(operandType))
+		{
+			throw new ArgumentException(
+				$"{resolverName} does not support operand type '{operandType}'.");
+		}
+
+		return PromoteNumericTypes(operandType, operandType);
+	}
+
+	internal static bool IsNumericType(Type type)
+	{
+		return type == typeof(byte)
+			|| type == typeof(sbyte)
+			|| type == typeof(short)
+			|| type == typeof(ushort)
+			|| type == typeof(int)
+			|| type == typeof(uint)
+			|| type == typeof(long)
+			|| type == typeof(ulong)
+			|| type == typeof(float)
+			|| type == typeof(double)
+			|| type == typeof(decimal);
+	}
+
+	internal static bool IsVectorType(Type type)
+	{
+		return type == typeof(Vector2)
+			|| type == typeof(Vector3)
+			|| type == typeof(Vector4);
+	}
+
+	internal static bool IsVectorOrQuaternionType(Type type)
+	{
+		return IsVectorType(type) || type == typeof(Quaternion);
+	}
+
+	internal static Type PromoteNumericTypes(Type leftType, Type rightType)
+	{
+		var leftRank = GetNumericRank(leftType);
+		var rightRank = GetNumericRank(rightType);
+
+		return leftRank >= rightRank ? RankToType(leftRank) : RankToType(rightRank);
+	}
+
+	internal static int ResolveAsInt(Type type, Variant128 value)
+	{
+		if (type == typeof(int))
+		{
+			return value.AsInt();
+		}
+
+		if (type == typeof(byte))
+		{
+			return value.AsByte();
+		}
+
+		if (type == typeof(sbyte))
+		{
+			return value.AsSByte();
+		}
+
+		if (type == typeof(short))
+		{
+			return value.AsShort();
+		}
+
+		if (type == typeof(ushort))
+		{
+			return value.AsUShort();
+		}
+
+		throw new InvalidOperationException($"Cannot convert '{type}' to int.");
+	}
+
+	internal static long ResolveAsLong(Type type, Variant128 value)
+	{
+		if (type == typeof(long))
+		{
+			return value.AsLong();
+		}
+
+		if (type == typeof(uint))
+		{
+			return value.AsUInt();
+		}
+
+		if (type == typeof(int))
+		{
+			return value.AsInt();
+		}
+
+		if (type == typeof(byte))
+		{
+			return value.AsByte();
+		}
+
+		if (type == typeof(sbyte))
+		{
+			return value.AsSByte();
+		}
+
+		if (type == typeof(short))
+		{
+			return value.AsShort();
+		}
+
+		if (type == typeof(ushort))
+		{
+			return value.AsUShort();
+		}
+
+		throw new InvalidOperationException($"Cannot convert '{type}' to long.");
+	}
+
+	internal static float ResolveAsFloat(Type type, Variant128 value)
+	{
+		if (type == typeof(float))
+		{
+			return value.AsFloat();
+		}
+
+		if (type == typeof(int))
+		{
+			return value.AsInt();
+		}
+
+		if (type == typeof(byte))
+		{
+			return value.AsByte();
+		}
+
+		if (type == typeof(sbyte))
+		{
+			return value.AsSByte();
+		}
+
+		if (type == typeof(short))
+		{
+			return value.AsShort();
+		}
+
+		if (type == typeof(ushort))
+		{
+			return value.AsUShort();
+		}
+
+		throw new InvalidOperationException($"Cannot convert '{type}' to float.");
+	}
+
+	internal static double ResolveAsDouble(Type type, Variant128 value)
+	{
+		if (type == typeof(double))
+		{
+			return value.AsDouble();
+		}
+
+		if (type == typeof(float))
+		{
+			return value.AsFloat();
+		}
+
+		if (type == typeof(long))
+		{
+			return value.AsLong();
+		}
+
+		if (type == typeof(ulong))
+		{
+			return value.AsULong();
+		}
+
+		if (type == typeof(uint))
+		{
+			return value.AsUInt();
+		}
+
+		if (type == typeof(int))
+		{
+			return value.AsInt();
+		}
+
+		if (type == typeof(byte))
+		{
+			return value.AsByte();
+		}
+
+		if (type == typeof(sbyte))
+		{
+			return value.AsSByte();
+		}
+
+		if (type == typeof(short))
+		{
+			return value.AsShort();
+		}
+
+		if (type == typeof(ushort))
+		{
+			return value.AsUShort();
+		}
+
+		throw new InvalidOperationException($"Cannot convert '{type}' to double.");
+	}
+
+	internal static decimal ResolveAsDecimal(Type type, Variant128 value)
+	{
+		if (type == typeof(decimal))
+		{
+			return value.AsDecimal();
+		}
+
+		if (type == typeof(double))
+		{
+			return (decimal)value.AsDouble();
+		}
+
+		if (type == typeof(float))
+		{
+			return (decimal)value.AsFloat();
+		}
+
+		if (type == typeof(long))
+		{
+			return value.AsLong();
+		}
+
+		if (type == typeof(ulong))
+		{
+			return value.AsULong();
+		}
+
+		if (type == typeof(uint))
+		{
+			return value.AsUInt();
+		}
+
+		if (type == typeof(int))
+		{
+			return value.AsInt();
+		}
+
+		if (type == typeof(byte))
+		{
+			return value.AsByte();
+		}
+
+		if (type == typeof(sbyte))
+		{
+			return value.AsSByte();
+		}
+
+		if (type == typeof(short))
+		{
+			return value.AsShort();
+		}
+
+		if (type == typeof(ushort))
+		{
+			return value.AsUShort();
+		}
+
+		throw new InvalidOperationException($"Cannot convert '{type}' to decimal.");
+	}
+
+	/// <summary>
+	/// Rank determines promotion order. Types with the same rank are identical.
+	/// The ranking follows C# numeric promotion rules:
+	/// byte/sbyte/short/ushort → int → uint → long → ulong → float → double → decimal.
+	/// </summary>
+	/// <param name="type">The numeric type to rank.</param>
+	/// <returns>The rank of the numeric type.</returns>
+	/// <exception cref="ArgumentException">Thrown when the type is not a supported numeric type.</exception>
+	private static int GetNumericRank(Type type)
+	{
+		if (type == typeof(byte) || type == typeof(sbyte) || type == typeof(short) || type == typeof(ushort))
+		{
+			return 0;
+		}
+
+		if (type == typeof(int))
+		{
+			return 1;
+		}
+
+		if (type == typeof(uint))
+		{
+			return 2;
+		}
+
+		if (type == typeof(long))
+		{
+			return 3;
+		}
+
+		if (type == typeof(ulong))
+		{
+			return 4;
+		}
+
+		if (type == typeof(float))
+		{
+			return 5;
+		}
+
+		if (type == typeof(double))
+		{
+			return 6;
+		}
+
+		if (type == typeof(decimal))
+		{
+			return 7;
+		}
+
+		throw new ArgumentException($"Unsupported numeric type '{type}'.");
+	}
+
+	private static Type RankToType(int rank)
+	{
+		return rank switch
+		{
+			0 => typeof(int),
+			1 => typeof(int),
+			2 => typeof(long),
+			3 => typeof(long),
+			4 => typeof(double),
+			5 => typeof(float),
+			6 => typeof(double),
+			7 => typeof(decimal),
+			_ => throw new ArgumentException($"Invalid numeric rank '{rank}'."),
+		};
+	}
+}

--- a/Forge/Statescript/Properties/MathTypeUtils.cs
+++ b/Forge/Statescript/Properties/MathTypeUtils.cs
@@ -10,8 +10,8 @@ namespace Gamesmiths.Forge.Statescript.Properties;
 internal static class MathTypeUtils
 {
 	/// <summary>
-	/// Determines the result type for a binary operation between two operand types, applying standard
-	/// C# numeric promotion rules. Vector and quaternion types must match exactly.
+	/// Determines the result type for a binary operation between two operand types, applying standard C# numeric
+	/// promotion rules. Vector and quaternion types must match exactly.
 	/// </summary>
 	/// <param name="resolverName">The name of the resolver (for error messages).</param>
 	/// <param name="leftType">The type of the left operand.</param>

--- a/Forge/Statescript/Properties/MathTypeUtils.cs
+++ b/Forge/Statescript/Properties/MathTypeUtils.cs
@@ -383,6 +383,158 @@ internal static class MathTypeUtils
 	}
 
 	/// <summary>
+	/// Determines the result type for a ternary operation (e.g., Clamp) among three operand types, applying standard
+	/// C# numeric promotion rules.
+	/// </summary>
+	/// <param name="resolverName">The name of the resolver (for error messages).</param>
+	/// <param name="type1">The type of the first operand.</param>
+	/// <param name="type2">The type of the second operand.</param>
+	/// <param name="type3">The type of the third operand.</param>
+	/// <returns>The promoted result type.</returns>
+	/// <exception cref="ArgumentException">Thrown when the type combination is unsupported.</exception>
+	internal static Type DetermineTernaryResultType(
+		string resolverName,
+		Type type1,
+		Type type2,
+		Type type3)
+	{
+		if (IsVectorOrQuaternionType(type1))
+		{
+			throw new ArgumentException($"{resolverName} does not support operand type '{type1}'.");
+		}
+
+		if (IsVectorOrQuaternionType(type2))
+		{
+			throw new ArgumentException($"{resolverName} does not support operand type '{type2}'.");
+		}
+
+		if (IsVectorOrQuaternionType(type3))
+		{
+			throw new ArgumentException($"{resolverName} does not support operand type '{type3}'.");
+		}
+
+		if (!IsNumericType(type1))
+		{
+			throw new ArgumentException($"{resolverName} does not support operand type '{type1}'.");
+		}
+
+		if (!IsNumericType(type2))
+		{
+			throw new ArgumentException($"{resolverName} does not support operand type '{type2}'.");
+		}
+
+		if (!IsNumericType(type3))
+		{
+			throw new ArgumentException($"{resolverName} does not support operand type '{type3}'.");
+		}
+
+		Type promoted = PromoteNumericTypes(type1, type2);
+		return PromoteNumericTypes(promoted, type3);
+	}
+
+	/// <summary>
+	/// Determines the result type for a floating-point-only unary operation (e.g., Floor, Ceil, Round, Truncate).
+	/// Only <see langword="float"/>, <see langword="double"/>, and <see langword="decimal"/> are supported.
+	/// </summary>
+	/// <param name="resolverName">The name of the resolver (for error messages).</param>
+	/// <param name="operandType">The type of the operand.</param>
+	/// <returns>The result type (same as the operand type).</returns>
+	/// <exception cref="ArgumentException">Thrown when the type is not a supported floating-point type.</exception>
+	internal static Type DetermineFloatingPointUnaryResultType(string resolverName, Type operandType)
+	{
+		if (operandType == typeof(float) || operandType == typeof(double) || operandType == typeof(decimal))
+		{
+			return operandType;
+		}
+
+		throw new ArgumentException(
+			$"{resolverName} only supports floating-point types (float, double, decimal). Got '{operandType}'.");
+	}
+
+	/// <summary>
+	/// Determines the result type for a floating-point-only binary operation (e.g., Pow). Only
+	/// <see langword="float"/> and <see langword="double"/> are supported. Integer operand types are promoted to
+	/// <see langword="double"/>.
+	/// </summary>
+	/// <param name="resolverName">The name of the resolver (for error messages).</param>
+	/// <param name="leftType">The type of the left operand.</param>
+	/// <param name="rightType">The type of the right operand.</param>
+	/// <returns>The result type.</returns>
+	/// <exception cref="ArgumentException">Thrown when the type combination is unsupported.</exception>
+	internal static Type DetermineFloatingPointBinaryResultType(
+		string resolverName,
+		Type leftType,
+		Type rightType)
+	{
+		if (IsVectorOrQuaternionType(leftType))
+		{
+			throw new ArgumentException($"{resolverName} does not support operand type '{leftType}'.");
+		}
+
+		if (IsVectorOrQuaternionType(rightType))
+		{
+			throw new ArgumentException($"{resolverName} does not support operand type '{rightType}'.");
+		}
+
+		if (!IsNumericType(leftType))
+		{
+			throw new ArgumentException($"{resolverName} does not support operand type '{leftType}'.");
+		}
+
+		if (!IsNumericType(rightType))
+		{
+			throw new ArgumentException($"{resolverName} does not support operand type '{rightType}'.");
+		}
+
+		if (leftType == typeof(decimal) || rightType == typeof(decimal))
+		{
+			throw new ArgumentException($"{resolverName} does not support decimal operands. Use double instead.");
+		}
+
+		// If both are float, result is float; otherwise promote to double.
+		if (leftType == typeof(float) && rightType == typeof(float))
+		{
+			return typeof(float);
+		}
+
+		return typeof(double);
+	}
+
+	/// <summary>
+	/// Determines the result type for a floating-point-only unary operation where integer types are promoted to
+	/// <see langword="double"/> (e.g., Sqrt). Only <see langword="float"/>, <see langword="double"/>, and integer
+	/// types are supported.
+	/// </summary>
+	/// <param name="resolverName">The name of the resolver (for error messages).</param>
+	/// <param name="operandType">The type of the operand.</param>
+	/// <returns>The result type.</returns>
+	/// <exception cref="ArgumentException">Thrown when the type is not supported.</exception>
+	internal static Type DetermineFloatingPointPromotedUnaryResultType(string resolverName, Type operandType)
+	{
+		if (IsVectorOrQuaternionType(operandType))
+		{
+			throw new ArgumentException($"{resolverName} does not support operand type '{operandType}'.");
+		}
+
+		if (!IsNumericType(operandType))
+		{
+			throw new ArgumentException($"{resolverName} does not support operand type '{operandType}'.");
+		}
+
+		if (operandType == typeof(decimal))
+		{
+			throw new ArgumentException($"{resolverName} does not support decimal operands. Use double instead.");
+		}
+
+		if (operandType == typeof(float))
+		{
+			return typeof(float);
+		}
+
+		return typeof(double);
+	}
+
+	/// <summary>
 	/// Rank determines promotion order. Types with the same rank are identical.
 	/// The ranking follows C# numeric promotion rules:
 	/// byte/sbyte/short/ushort → int → uint → long → ulong → float → double → decimal.

--- a/Forge/Statescript/Properties/MaxResolver.cs
+++ b/Forge/Statescript/Properties/MaxResolver.cs
@@ -1,0 +1,75 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the maximum of two nested <see cref="IPropertyResolver"/> operands. Supports all numeric types in
+/// <see cref="Variant128"/>. Vector and quaternion types are not supported. When the two operands have different
+/// numeric types, standard numeric promotion rules apply.
+/// </summary>
+/// <param name="left">The resolver for the left operand.</param>
+/// <param name="right">The resolver for the right operand.</param>
+public class MaxResolver(IPropertyResolver left, IPropertyResolver right) : IPropertyResolver
+{
+	private readonly IPropertyResolver _left = left;
+
+	private readonly IPropertyResolver _right = right;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineBinaryResultType(
+		nameof(MaxResolver),
+		left.ValueType,
+		right.ValueType,
+		allowVectors: false,
+		allowQuaternions: false);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 leftValue = _left.Resolve(graphContext);
+		Variant128 rightValue = _right.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(int))
+		{
+			return new Variant128(
+				Math.Max(
+					MathTypeUtils.ResolveAsInt(_left.ValueType, leftValue),
+					MathTypeUtils.ResolveAsInt(_right.ValueType, rightValue)));
+		}
+
+		if (resultType == typeof(long))
+		{
+			return new Variant128(
+				Math.Max(
+					MathTypeUtils.ResolveAsLong(_left.ValueType, leftValue),
+					MathTypeUtils.ResolveAsLong(_right.ValueType, rightValue)));
+		}
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(
+				Math.Max(
+					MathTypeUtils.ResolveAsFloat(_left.ValueType, leftValue),
+					MathTypeUtils.ResolveAsFloat(_right.ValueType, rightValue)));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(
+				Math.Max(
+					MathTypeUtils.ResolveAsDouble(_left.ValueType, leftValue),
+					MathTypeUtils.ResolveAsDouble(_right.ValueType, rightValue)));
+		}
+
+		if (resultType == typeof(decimal))
+		{
+			return new Variant128(
+				Math.Max(
+					MathTypeUtils.ResolveAsDecimal(_left.ValueType, leftValue),
+					MathTypeUtils.ResolveAsDecimal(_right.ValueType, rightValue)));
+		}
+
+		throw new InvalidOperationException($"MaxResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/MinResolver.cs
+++ b/Forge/Statescript/Properties/MinResolver.cs
@@ -1,0 +1,75 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the minimum of two nested <see cref="IPropertyResolver"/> operands. Supports all numeric types in
+/// <see cref="Variant128"/>. Vector and quaternion types are not supported. When the two operands have different
+/// numeric types, standard numeric promotion rules apply.
+/// </summary>
+/// <param name="left">The resolver for the left operand.</param>
+/// <param name="right">The resolver for the right operand.</param>
+public class MinResolver(IPropertyResolver left, IPropertyResolver right) : IPropertyResolver
+{
+	private readonly IPropertyResolver _left = left;
+
+	private readonly IPropertyResolver _right = right;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineBinaryResultType(
+		nameof(MinResolver),
+		left.ValueType,
+		right.ValueType,
+		allowVectors: false,
+		allowQuaternions: false);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 leftValue = _left.Resolve(graphContext);
+		Variant128 rightValue = _right.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(int))
+		{
+			return new Variant128(
+				Math.Min(
+					MathTypeUtils.ResolveAsInt(_left.ValueType, leftValue),
+					MathTypeUtils.ResolveAsInt(_right.ValueType, rightValue)));
+		}
+
+		if (resultType == typeof(long))
+		{
+			return new Variant128(
+				Math.Min(
+					MathTypeUtils.ResolveAsLong(_left.ValueType, leftValue),
+					MathTypeUtils.ResolveAsLong(_right.ValueType, rightValue)));
+		}
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(
+				Math.Min(
+					MathTypeUtils.ResolveAsFloat(_left.ValueType, leftValue),
+					MathTypeUtils.ResolveAsFloat(_right.ValueType, rightValue)));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(
+				Math.Min(
+					MathTypeUtils.ResolveAsDouble(_left.ValueType, leftValue),
+					MathTypeUtils.ResolveAsDouble(_right.ValueType, rightValue)));
+		}
+
+		if (resultType == typeof(decimal))
+		{
+			return new Variant128(
+				Math.Min(
+					MathTypeUtils.ResolveAsDecimal(_left.ValueType, leftValue),
+					MathTypeUtils.ResolveAsDecimal(_right.ValueType, rightValue)));
+		}
+
+		throw new InvalidOperationException($"MinResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/ModuloResolver.cs
+++ b/Forge/Statescript/Properties/ModuloResolver.cs
@@ -1,0 +1,71 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the remainder (modulo) of dividing two nested <see cref="IPropertyResolver"/> operands. Supports all
+/// numeric types in <see cref="Variant128"/>. Vector and quaternion types are not supported. When the two operands
+/// have different numeric types, standard numeric promotion rules apply.
+/// </summary>
+/// <param name="left">The resolver for the left (dividend) operand.</param>
+/// <param name="right">The resolver for the right (divisor) operand.</param>
+public class ModuloResolver(IPropertyResolver left, IPropertyResolver right) : IPropertyResolver
+{
+	private readonly IPropertyResolver _left = left;
+
+	private readonly IPropertyResolver _right = right;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineBinaryResultType(
+		nameof(ModuloResolver),
+		left.ValueType,
+		right.ValueType,
+		allowVectors: false,
+		allowQuaternions: false);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 leftValue = _left.Resolve(graphContext);
+		Variant128 rightValue = _right.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(int))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsInt(_left.ValueType, leftValue)
+				% MathTypeUtils.ResolveAsInt(_right.ValueType, rightValue));
+		}
+
+		if (resultType == typeof(long))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsLong(_left.ValueType, leftValue)
+				% MathTypeUtils.ResolveAsLong(_right.ValueType, rightValue));
+		}
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsFloat(_left.ValueType, leftValue)
+				% MathTypeUtils.ResolveAsFloat(_right.ValueType, rightValue));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsDouble(_left.ValueType, leftValue)
+				% MathTypeUtils.ResolveAsDouble(_right.ValueType, rightValue));
+		}
+
+		if (resultType == typeof(decimal))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsDecimal(_left.ValueType, leftValue)
+				% MathTypeUtils.ResolveAsDecimal(_right.ValueType, rightValue));
+		}
+
+		throw new InvalidOperationException(
+			$"ModuloResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/MultiplyResolver.cs
+++ b/Forge/Statescript/Properties/MultiplyResolver.cs
@@ -1,0 +1,93 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the product of two nested <see cref="IPropertyResolver"/> operands. Supports all numeric types in
+/// <see cref="Variant128"/> as well as <see cref="Vector2"/>, <see cref="Vector3"/>, <see cref="Vector4"/>
+/// (component-wise multiplication), and <see cref="Quaternion"/> (quaternion multiplication). When the two operands
+/// have different numeric types, standard numeric promotion rules apply. Vector and quaternion operands must match
+/// exactly.
+/// </summary>
+/// <param name="left">The resolver for the left operand.</param>
+/// <param name="right">The resolver for the right operand.</param>
+public class MultiplyResolver(IPropertyResolver left, IPropertyResolver right) : IPropertyResolver
+{
+	private readonly IPropertyResolver _left = left;
+
+	private readonly IPropertyResolver _right = right;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineBinaryResultType(
+		nameof(MultiplyResolver),
+		left.ValueType,
+		right.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 leftValue = _left.Resolve(graphContext);
+		Variant128 rightValue = _right.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(int))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsInt(_left.ValueType, leftValue)
+				* MathTypeUtils.ResolveAsInt(_right.ValueType, rightValue));
+		}
+
+		if (resultType == typeof(long))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsLong(_left.ValueType, leftValue)
+				* MathTypeUtils.ResolveAsLong(_right.ValueType, rightValue));
+		}
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsFloat(_left.ValueType, leftValue)
+				* MathTypeUtils.ResolveAsFloat(_right.ValueType, rightValue));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsDouble(_left.ValueType, leftValue)
+				* MathTypeUtils.ResolveAsDouble(_right.ValueType, rightValue));
+		}
+
+		if (resultType == typeof(decimal))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsDecimal(_left.ValueType, leftValue)
+				* MathTypeUtils.ResolveAsDecimal(_right.ValueType, rightValue));
+		}
+
+		if (resultType == typeof(Vector2))
+		{
+			return new Variant128(leftValue.AsVector2() * rightValue.AsVector2());
+		}
+
+		if (resultType == typeof(Vector3))
+		{
+			return new Variant128(leftValue.AsVector3() * rightValue.AsVector3());
+		}
+
+		if (resultType == typeof(Vector4))
+		{
+			return new Variant128(leftValue.AsVector4() * rightValue.AsVector4());
+		}
+
+		if (resultType == typeof(Quaternion))
+		{
+			return new Variant128(leftValue.AsQuaternion() * rightValue.AsQuaternion());
+		}
+
+		throw new InvalidOperationException(
+			$"MultiplyResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/NegateResolver.cs
+++ b/Forge/Statescript/Properties/NegateResolver.cs
@@ -1,0 +1,76 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the arithmetic negation of a single <see cref="IPropertyResolver"/> operand. Supports all numeric types
+/// in <see cref="Variant128"/> as well as <see cref="Vector2"/>, <see cref="Vector3"/>, <see cref="Vector4"/>, and
+/// <see cref="Quaternion"/>. Sub-int types are promoted to <see langword="int"/> following standard C# rules.
+/// </summary>
+/// <param name="operand">The resolver for the operand to negate.</param>
+public class NegateResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineUnaryResultType(
+		nameof(NegateResolver),
+		operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(int))
+		{
+			return new Variant128(-MathTypeUtils.ResolveAsInt(_operand.ValueType, value));
+		}
+
+		if (resultType == typeof(long))
+		{
+			return new Variant128(-MathTypeUtils.ResolveAsLong(_operand.ValueType, value));
+		}
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(-MathTypeUtils.ResolveAsFloat(_operand.ValueType, value));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(-MathTypeUtils.ResolveAsDouble(_operand.ValueType, value));
+		}
+
+		if (resultType == typeof(decimal))
+		{
+			return new Variant128(-MathTypeUtils.ResolveAsDecimal(_operand.ValueType, value));
+		}
+
+		if (resultType == typeof(Vector2))
+		{
+			return new Variant128(-value.AsVector2());
+		}
+
+		if (resultType == typeof(Vector3))
+		{
+			return new Variant128(-value.AsVector3());
+		}
+
+		if (resultType == typeof(Vector4))
+		{
+			return new Variant128(-value.AsVector4());
+		}
+
+		if (resultType == typeof(Quaternion))
+		{
+			return new Variant128(-value.AsQuaternion());
+		}
+
+		throw new InvalidOperationException(
+			$"NegateResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/PiResolver.cs
+++ b/Forge/Statescript/Properties/PiResolver.cs
@@ -1,0 +1,37 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the mathematical constant π (pi). Returns <see langword="double"/> by default, or <see langword="float"/>
+/// if explicitly requested. This avoids magic numbers and communicates intent clearly.
+/// </summary>
+/// <param name="valueType">The desired output type. Must be <see langword="float"/> or <see langword="double"/>.
+/// Defaults to <see langword="double"/> if not specified.</param>
+public class PiResolver(Type? valueType = null) : IPropertyResolver
+{
+	/// <inheritdoc/>
+	public Type ValueType { get; } = ValidateType(valueType ?? typeof(double));
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		if (ValueType == typeof(float))
+		{
+			return new Variant128(MathF.PI);
+		}
+
+		return new Variant128(Math.PI);
+	}
+
+	private static Type ValidateType(Type type)
+	{
+		if (type != typeof(float) && type != typeof(double))
+		{
+			throw new ArgumentException(
+				$"PiResolver only supports float and double output types. Got '{type}'.");
+		}
+
+		return type;
+	}
+}

--- a/Forge/Statescript/Properties/PowResolver.cs
+++ b/Forge/Statescript/Properties/PowResolver.cs
@@ -1,0 +1,49 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves a value raised to a specified power using two nested <see cref="IPropertyResolver"/> operands. Supports
+/// <see langword="float"/> and <see langword="double"/> types. Integer operand types are promoted to
+/// <see langword="double"/>. Decimal, vector, and quaternion types are not supported.
+/// </summary>
+/// <param name="baseOperand">The resolver for the base operand.</param>
+/// <param name="exponent">The resolver for the exponent operand.</param>
+public class PowResolver(IPropertyResolver baseOperand, IPropertyResolver exponent) : IPropertyResolver
+{
+	private readonly IPropertyResolver _base = baseOperand;
+
+	private readonly IPropertyResolver _exponent = exponent;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointBinaryResultType(
+		nameof(PowResolver),
+		baseOperand.ValueType,
+		exponent.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 baseValue = _base.Resolve(graphContext);
+		Variant128 expValue = _exponent.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(
+				MathF.Pow(
+					MathTypeUtils.ResolveAsFloat(_base.ValueType, baseValue),
+					MathTypeUtils.ResolveAsFloat(_exponent.ValueType, expValue)));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(
+				Math.Pow(
+					MathTypeUtils.ResolveAsDouble(_base.ValueType, baseValue),
+					MathTypeUtils.ResolveAsDouble(_exponent.ValueType, expValue)));
+		}
+
+		throw new InvalidOperationException($"PowResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/RadToDegResolver.cs
+++ b/Forge/Statescript/Properties/RadToDegResolver.cs
@@ -1,0 +1,40 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves a conversion from radians to degrees using a single <see cref="IPropertyResolver"/> operand. Computes
+/// <c>radians * (180 / π)</c>. Supports <see langword="float"/> and <see langword="double"/> types. Integer operand
+/// types are promoted to <see langword="double"/>. Decimal, vector, and quaternion types are not supported.
+/// </summary>
+/// <param name="operand">The resolver for the operand (angle in radians).</param>
+public class RadToDegResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointPromotedUnaryResultType(
+		nameof(RadToDegResolver),
+		operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(value.AsFloat() * (180.0f / MathF.PI));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsDouble(_operand.ValueType, value) * (180.0 / Math.PI));
+		}
+
+		throw new InvalidOperationException(
+			$"RadToDegResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/RandomResolver.cs
+++ b/Forge/Statescript/Properties/RandomResolver.cs
@@ -1,0 +1,124 @@
+// Copyright © Gamesmiths Guild.
+
+using Gamesmiths.Forge.Core;
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves a random value within a range defined by two <see cref="IPropertyResolver"/> operands, using a provided
+/// <see cref="IRandom"/> implementation. The random value is in the range [min, max) for floating-point types and
+/// [min, max) for integer types. Supports <see langword="int"/>, <see langword="float"/>, and
+/// <see langword="double"/> types. Other numeric, vector, and quaternion types are not supported.
+/// </summary>
+/// <param name="random">The random provider to use for generating values.</param>
+/// <param name="min">The resolver for the inclusive minimum bound.</param>
+/// <param name="max">The resolver for the exclusive maximum bound.</param>
+public class RandomResolver(IRandom random, IPropertyResolver min, IPropertyResolver max) : IPropertyResolver
+{
+	private readonly IRandom _random = random;
+
+	private readonly IPropertyResolver _min = min;
+
+	private readonly IPropertyResolver _max = max;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = DetermineResultType(min.ValueType, max.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 minValue = _min.Resolve(graphContext);
+		Variant128 maxValue = _max.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(int))
+		{
+			return new Variant128(
+				_random.NextInt(
+					MathTypeUtils.ResolveAsInt(_min.ValueType, minValue),
+					MathTypeUtils.ResolveAsInt(_max.ValueType, maxValue)));
+		}
+
+		if (resultType == typeof(float))
+		{
+			var minFloat = MathTypeUtils.ResolveAsFloat(_min.ValueType, minValue);
+			var maxFloat = MathTypeUtils.ResolveAsFloat(_max.ValueType, maxValue);
+			return new Variant128(minFloat + (_random.NextSingle() * (maxFloat - minFloat)));
+		}
+
+		if (resultType == typeof(double))
+		{
+			var minDouble = MathTypeUtils.ResolveAsDouble(_min.ValueType, minValue);
+			var maxDouble = MathTypeUtils.ResolveAsDouble(_max.ValueType, maxValue);
+			return new Variant128(minDouble + (_random.NextDouble() * (maxDouble - minDouble)));
+		}
+
+		throw new InvalidOperationException(
+			$"RandomResolver encountered unexpected result type '{resultType}'.");
+	}
+
+	private static Type DetermineResultType(Type minType, Type maxType)
+	{
+		if (MathTypeUtils.IsVectorOrQuaternionType(minType))
+		{
+			throw new ArgumentException($"RandomResolver does not support operand type '{minType}'.");
+		}
+
+		if (MathTypeUtils.IsVectorOrQuaternionType(maxType))
+		{
+			throw new ArgumentException($"RandomResolver does not support operand type '{maxType}'.");
+		}
+
+		if (!MathTypeUtils.IsNumericType(minType))
+		{
+			throw new ArgumentException($"RandomResolver does not support operand type '{minType}'.");
+		}
+
+		if (!MathTypeUtils.IsNumericType(maxType))
+		{
+			throw new ArgumentException($"RandomResolver does not support operand type '{maxType}'.");
+		}
+
+		if (minType == typeof(decimal) || maxType == typeof(decimal))
+		{
+			throw new ArgumentException("RandomResolver does not support decimal operands. Use double instead.");
+		}
+
+		if (minType == typeof(long) || maxType == typeof(long)
+			|| minType == typeof(uint) || maxType == typeof(uint)
+			|| minType == typeof(ulong) || maxType == typeof(ulong))
+		{
+			throw new ArgumentException("RandomResolver only supports int, float, and double operand types.");
+		}
+
+		// Both int (or sub-int) → int.
+		if (IsIntOrSubInt(minType) && IsIntOrSubInt(maxType))
+		{
+			return typeof(int);
+		}
+
+		// Both float → float; otherwise double.
+		if (minType == typeof(float) && maxType == typeof(float))
+		{
+			return typeof(float);
+		}
+
+		// Mixed int/float promotes to float for practical game use.
+		if ((IsIntOrSubInt(minType) && maxType == typeof(float))
+			|| (minType == typeof(float) && IsIntOrSubInt(maxType)))
+		{
+			return typeof(float);
+		}
+
+		return typeof(double);
+	}
+
+	private static bool IsIntOrSubInt(Type type)
+	{
+		return type == typeof(int)
+			|| type == typeof(byte)
+			|| type == typeof(sbyte)
+			|| type == typeof(short)
+			|| type == typeof(ushort);
+	}
+}

--- a/Forge/Statescript/Properties/RandomResolver.cs
+++ b/Forge/Statescript/Properties/RandomResolver.cs
@@ -6,9 +6,11 @@ namespace Gamesmiths.Forge.Statescript.Properties;
 
 /// <summary>
 /// Resolves a random value within a range defined by two <see cref="IPropertyResolver"/> operands, using a provided
-/// <see cref="IRandom"/> implementation. The random value is in the range [min, max) for floating-point types and
-/// [min, max) for integer types. Supports <see langword="int"/>, <see langword="float"/>, and
-/// <see langword="double"/> types. Other numeric, vector, and quaternion types are not supported.
+/// <see cref="IRandom"/> implementation. The random value is in the range [min, max) for both integer and
+/// floating-point types. Supports <see langword="int"/>, <see langword="float"/>, and <see langword="double"/>
+/// types. Sub-int operand types (<see langword="byte"/>, <see langword="sbyte"/>, <see langword="short"/>,
+/// <see langword="ushort"/>) are promoted to <see langword="int"/>. Other numeric, vector, and quaternion types are
+/// not supported.
 /// </summary>
 /// <param name="random">The random provider to use for generating values.</param>
 /// <param name="min">The resolver for the inclusive minimum bound.</param>

--- a/Forge/Statescript/Properties/RoundResolver.cs
+++ b/Forge/Statescript/Properties/RoundResolver.cs
@@ -1,0 +1,43 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the nearest integer to the operand using banker's rounding (<see cref="MidpointRounding.ToEven"/>).
+/// Supports <see langword="float"/>, <see langword="double"/>, and <see langword="decimal"/> types only. Integer,
+/// vector, and quaternion types are not supported.
+/// </summary>
+/// <param name="operand">The resolver for the operand.</param>
+public class RoundResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointUnaryResultType(
+		nameof(RoundResolver),
+		operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(MathF.Round(value.AsFloat()));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(Math.Round(value.AsDouble()));
+		}
+
+		if (resultType == typeof(decimal))
+		{
+			return new Variant128(Math.Round(value.AsDecimal()));
+		}
+
+		throw new InvalidOperationException($"RoundResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/RoundResolver.cs
+++ b/Forge/Statescript/Properties/RoundResolver.cs
@@ -3,14 +3,25 @@
 namespace Gamesmiths.Forge.Statescript.Properties;
 
 /// <summary>
-/// Resolves the nearest integer to the operand using banker's rounding (<see cref="MidpointRounding.ToEven"/>).
-/// Supports <see langword="float"/>, <see langword="double"/>, and <see langword="decimal"/> types only. Integer,
-/// vector, and quaternion types are not supported.
+/// Resolves rounding of a single <see cref="IPropertyResolver"/> operand. Supports <see langword="float"/>,
+/// <see langword="double"/>, and <see langword="decimal"/> types only. Integer, vector, and quaternion types are not
+/// supported.
 /// </summary>
 /// <param name="operand">The resolver for the operand.</param>
-public class RoundResolver(IPropertyResolver operand) : IPropertyResolver
+/// <param name="digits">The number of fractional digits in the return value. Defaults to <c>0</c> (round to nearest
+/// integer).</param>
+/// <param name="mode">The rounding strategy to use. Defaults to <see cref="MidpointRounding.ToEven"/> (banker's
+/// rounding).</param>
+public class RoundResolver(
+	IPropertyResolver operand,
+	int digits = 0,
+	MidpointRounding mode = MidpointRounding.ToEven) : IPropertyResolver
 {
 	private readonly IPropertyResolver _operand = operand;
+
+	private readonly int _digits = ValidateDigits(digits);
+
+	private readonly MidpointRounding _mode = mode;
 
 	/// <inheritdoc/>
 	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointUnaryResultType(
@@ -25,19 +36,32 @@ public class RoundResolver(IPropertyResolver operand) : IPropertyResolver
 
 		if (resultType == typeof(float))
 		{
-			return new Variant128(MathF.Round(value.AsFloat()));
+			return new Variant128(MathF.Round(value.AsFloat(), _digits, _mode));
 		}
 
 		if (resultType == typeof(double))
 		{
-			return new Variant128(Math.Round(value.AsDouble()));
+			return new Variant128(Math.Round(value.AsDouble(), _digits, _mode));
 		}
 
 		if (resultType == typeof(decimal))
 		{
-			return new Variant128(Math.Round(value.AsDecimal()));
+			return new Variant128(Math.Round(value.AsDecimal(), _digits, _mode));
 		}
 
 		throw new InvalidOperationException($"RoundResolver encountered unexpected result type '{resultType}'.");
+	}
+
+	private static int ValidateDigits(int digits)
+	{
+		if (digits < 0 || digits > 15)
+		{
+			throw new ArgumentOutOfRangeException(
+				nameof(digits),
+				digits,
+				"Digits must be between 0 and 15.");
+		}
+
+		return digits;
 	}
 }

--- a/Forge/Statescript/Properties/SignResolver.cs
+++ b/Forge/Statescript/Properties/SignResolver.cs
@@ -1,0 +1,81 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the sign of a single <see cref="IPropertyResolver"/> operand, returning <c>-1</c>, <c>0</c>, or <c>1</c>
+/// as an <see langword="int"/>. Supports all numeric types in <see cref="Variant128"/>. Vector and quaternion types
+/// are not supported. The result is always <see langword="int"/> regardless of the operand type.
+/// </summary>
+/// <param name="operand">The resolver for the operand.</param>
+public class SignResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = DetermineResultType(operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type operandType = _operand.ValueType;
+
+		if (operandType == typeof(float))
+		{
+			return new Variant128(MathF.Sign(value.AsFloat()));
+		}
+
+		if (operandType == typeof(double))
+		{
+			return new Variant128(Math.Sign(value.AsDouble()));
+		}
+
+		if (operandType == typeof(decimal))
+		{
+			return new Variant128(Math.Sign(value.AsDecimal()));
+		}
+
+		if (operandType == typeof(long))
+		{
+			return new Variant128(Math.Sign(value.AsLong()));
+		}
+
+		if (operandType == typeof(int)
+			|| operandType == typeof(short)
+			|| operandType == typeof(sbyte))
+		{
+			return new Variant128(Math.Sign(MathTypeUtils.ResolveAsInt(operandType, value)));
+		}
+
+		throw new InvalidOperationException(
+			$"SignResolver encountered unexpected operand type '{operandType}'.");
+	}
+
+	private static Type DetermineResultType(Type operandType)
+	{
+		if (MathTypeUtils.IsVectorOrQuaternionType(operandType))
+		{
+			throw new ArgumentException(
+				$"SignResolver does not support operand type '{operandType}'.");
+		}
+
+		if (!MathTypeUtils.IsNumericType(operandType))
+		{
+			throw new ArgumentException(
+				$"SignResolver does not support operand type '{operandType}'.");
+		}
+
+		if (operandType == typeof(byte)
+			|| operandType == typeof(ushort)
+			|| operandType == typeof(uint)
+			|| operandType == typeof(ulong))
+		{
+			throw new ArgumentException(
+				$"SignResolver does not support unsigned type '{operandType}'. " +
+				"Sign is only meaningful for signed types.");
+		}
+
+		return typeof(int);
+	}
+}

--- a/Forge/Statescript/Properties/SinHResolver.cs
+++ b/Forge/Statescript/Properties/SinHResolver.cs
@@ -1,0 +1,39 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the hyperbolic sine of a single <see cref="IPropertyResolver"/> operand. Supports
+/// <see langword="float"/> and <see langword="double"/> types. Integer operand types are promoted to
+/// <see langword="double"/>. Decimal, vector, and quaternion types are not supported.
+/// </summary>
+/// <param name="operand">The resolver for the operand.</param>
+public class SinHResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointPromotedUnaryResultType(
+		nameof(SinHResolver),
+		operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(MathF.Sinh(value.AsFloat()));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(Math.Sinh(MathTypeUtils.ResolveAsDouble(_operand.ValueType, value)));
+		}
+
+		throw new InvalidOperationException(
+			$"SinHResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/SinResolver.cs
+++ b/Forge/Statescript/Properties/SinResolver.cs
@@ -1,0 +1,39 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the sine of a single <see cref="IPropertyResolver"/> operand (in radians). Supports
+/// <see langword="float"/> and <see langword="double"/> types. Integer operand types are promoted to
+/// <see langword="double"/>. Decimal, vector, and quaternion types are not supported.
+/// </summary>
+/// <param name="operand">The resolver for the operand (angle in radians).</param>
+public class SinResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointPromotedUnaryResultType(
+		nameof(SinResolver),
+		operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(MathF.Sin(value.AsFloat()));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(Math.Sin(MathTypeUtils.ResolveAsDouble(_operand.ValueType, value)));
+		}
+
+		throw new InvalidOperationException(
+			$"SinResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/SqrtResolver.cs
+++ b/Forge/Statescript/Properties/SqrtResolver.cs
@@ -1,0 +1,38 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the square root of a single <see cref="IPropertyResolver"/> operand. Supports <see langword="float"/> and
+/// <see langword="double"/> types. Integer operand types are promoted to <see langword="double"/>. Decimal, vector,
+/// and quaternion types are not supported.
+/// </summary>
+/// <param name="operand">The resolver for the operand.</param>
+public class SqrtResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointPromotedUnaryResultType(
+		nameof(SqrtResolver),
+		operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(MathF.Sqrt(value.AsFloat()));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(Math.Sqrt(MathTypeUtils.ResolveAsDouble(_operand.ValueType, value)));
+		}
+
+		throw new InvalidOperationException($"SqrtResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/SubtractResolver.cs
+++ b/Forge/Statescript/Properties/SubtractResolver.cs
@@ -1,0 +1,92 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Numerics;
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the difference of two nested <see cref="IPropertyResolver"/> operands. Supports all numeric types in
+/// <see cref="Variant128"/> as well as <see cref="Vector2"/>, <see cref="Vector3"/>, <see cref="Vector4"/>, and
+/// <see cref="Quaternion"/>. When the two operands have different numeric types, standard numeric promotion rules
+/// apply. Vector and quaternion operands must match exactly.
+/// </summary>
+/// <param name="left">The resolver for the left operand.</param>
+/// <param name="right">The resolver for the right operand.</param>
+public class SubtractResolver(IPropertyResolver left, IPropertyResolver right) : IPropertyResolver
+{
+	private readonly IPropertyResolver _left = left;
+
+	private readonly IPropertyResolver _right = right;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineBinaryResultType(
+		nameof(SubtractResolver),
+		left.ValueType,
+		right.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 leftValue = _left.Resolve(graphContext);
+		Variant128 rightValue = _right.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(int))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsInt(_left.ValueType, leftValue)
+				- MathTypeUtils.ResolveAsInt(_right.ValueType, rightValue));
+		}
+
+		if (resultType == typeof(long))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsLong(_left.ValueType, leftValue)
+				- MathTypeUtils.ResolveAsLong(_right.ValueType, rightValue));
+		}
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsFloat(_left.ValueType, leftValue)
+				- MathTypeUtils.ResolveAsFloat(_right.ValueType, rightValue));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsDouble(_left.ValueType, leftValue)
+				- MathTypeUtils.ResolveAsDouble(_right.ValueType, rightValue));
+		}
+
+		if (resultType == typeof(decimal))
+		{
+			return new Variant128(
+				MathTypeUtils.ResolveAsDecimal(_left.ValueType, leftValue)
+				- MathTypeUtils.ResolveAsDecimal(_right.ValueType, rightValue));
+		}
+
+		if (resultType == typeof(Vector2))
+		{
+			return new Variant128(leftValue.AsVector2() - rightValue.AsVector2());
+		}
+
+		if (resultType == typeof(Vector3))
+		{
+			return new Variant128(leftValue.AsVector3() - rightValue.AsVector3());
+		}
+
+		if (resultType == typeof(Vector4))
+		{
+			return new Variant128(leftValue.AsVector4() - rightValue.AsVector4());
+		}
+
+		if (resultType == typeof(Quaternion))
+		{
+			return new Variant128(leftValue.AsQuaternion() - rightValue.AsQuaternion());
+		}
+
+		throw new InvalidOperationException(
+			$"SubtractResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/TanHResolver.cs
+++ b/Forge/Statescript/Properties/TanHResolver.cs
@@ -1,0 +1,39 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the hyperbolic tangent of a single <see cref="IPropertyResolver"/> operand. Supports
+/// <see langword="float"/> and <see langword="double"/> types. Integer operand types are promoted to
+/// <see langword="double"/>. Decimal, vector, and quaternion types are not supported.
+/// </summary>
+/// <param name="operand">The resolver for the operand.</param>
+public class TanHResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointPromotedUnaryResultType(
+		nameof(TanHResolver),
+		operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(MathF.Tanh(value.AsFloat()));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(Math.Tanh(MathTypeUtils.ResolveAsDouble(_operand.ValueType, value)));
+		}
+
+		throw new InvalidOperationException(
+			$"TanHResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/TanResolver.cs
+++ b/Forge/Statescript/Properties/TanResolver.cs
@@ -1,0 +1,39 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the tangent of a single <see cref="IPropertyResolver"/> operand (in radians). Supports
+/// <see langword="float"/> and <see langword="double"/> types. Integer operand types are promoted to
+/// <see langword="double"/>. Decimal, vector, and quaternion types are not supported.
+/// </summary>
+/// <param name="operand">The resolver for the operand (angle in radians).</param>
+public class TanResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointPromotedUnaryResultType(
+		nameof(TanResolver),
+		operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(MathF.Tan(value.AsFloat()));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(Math.Tan(MathTypeUtils.ResolveAsDouble(_operand.ValueType, value)));
+		}
+
+		throw new InvalidOperationException(
+			$"TanResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/Forge/Statescript/Properties/TruncateResolver.cs
+++ b/Forge/Statescript/Properties/TruncateResolver.cs
@@ -1,0 +1,43 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the integral part of a number by removing any fractional digits, rounding toward zero. Supports
+/// <see langword="float"/>, <see langword="double"/>, and <see langword="decimal"/> types only. Integer, vector, and
+/// quaternion types are not supported.
+/// </summary>
+/// <param name="operand">The resolver for the operand.</param>
+public class TruncateResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand = operand;
+
+	/// <inheritdoc/>
+	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointUnaryResultType(
+		nameof(TruncateResolver),
+		operand.ValueType);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 value = _operand.Resolve(graphContext);
+		Type resultType = ValueType;
+
+		if (resultType == typeof(float))
+		{
+			return new Variant128(MathF.Truncate(value.AsFloat()));
+		}
+
+		if (resultType == typeof(double))
+		{
+			return new Variant128(Math.Truncate(value.AsDouble()));
+		}
+
+		if (resultType == typeof(decimal))
+		{
+			return new Variant128(Math.Truncate(value.AsDecimal()));
+		}
+
+		throw new InvalidOperationException($"TruncateResolver encountered unexpected result type '{resultType}'.");
+	}
+}

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -33,6 +33,7 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [CbrtResolver](cbrt-resolver.md) | `float`/`double` | Computes the cube root. |
 | [CeilResolver](ceil-resolver.md) | *(same)* | Rounds up to the smallest integer greater than or equal to the operand. |
 | [ClampResolver](clamp-resolver.md) | *(promoted)* | Clamps a numeric value between a minimum and maximum bound. |
+| [CopySignResolver](copysign-resolver.md) | `float`/`double` | Returns a value with the magnitude of one operand and the sign of another. |
 | [CosHResolver](cosh-resolver.md) | `float`/`double` | Computes the hyperbolic cosine. |
 | [CosResolver](cos-resolver.md) | `float`/`double` | Computes the cosine of an angle in radians. |
 | [DivideResolver](divide-resolver.md) | *(promoted)* | Divides two numeric or vector values. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -24,6 +24,7 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [AbsResolver](abs-resolver.md) | *(promoted)* | Computes the absolute value of a signed numeric value. |
 | [AddResolver](add-resolver.md) | *(promoted)* | Adds two numeric or vector values. |
 | [DivideResolver](divide-resolver.md) | *(promoted)* | Divides two numeric or vector values. |
+| [LerpResolver](lerp-resolver.md) | `float`/`double`/vector/quaternion | Linearly interpolates between two values (scalar, vector, or quaternion). |
 | [ModuloResolver](modulo-resolver.md) | *(promoted)* | Computes the remainder of dividing two numeric values. |
 | [MultiplyResolver](multiply-resolver.md) | *(promoted)* | Multiplies two numeric or vector values. |
 | [NegateResolver](negate-resolver.md) | *(promoted)* | Negates a numeric or vector value. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -25,6 +25,7 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [AddResolver](add-resolver.md) | *(promoted)* | Adds two numeric or vector values. |
 | [DivideResolver](divide-resolver.md) | *(promoted)* | Divides two numeric or vector values. |
 | [LerpResolver](lerp-resolver.md) | `float`/`double`/vector/quaternion | Linearly interpolates between two values (scalar, vector, or quaternion). |
+| [MinResolver](min-resolver.md) | *(promoted)* | Returns the smaller of two numeric values. |
 | [ModuloResolver](modulo-resolver.md) | *(promoted)* | Computes the remainder of dividing two numeric values. |
 | [MultiplyResolver](multiply-resolver.md) | *(promoted)* | Multiplies two numeric or vector values. |
 | [NegateResolver](negate-resolver.md) | *(promoted)* | Negates a numeric or vector value. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -23,6 +23,7 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 |----------|-------------|-------------|
 | [AbsResolver](abs-resolver.md) | *(promoted)* | Computes the absolute value of a signed numeric value. |
 | [AddResolver](add-resolver.md) | *(promoted)* | Adds two numeric or vector values. |
+| [CeilResolver](ceil-resolver.md) | *(same)* | Rounds up to the smallest integer greater than or equal to the operand. |
 | [DivideResolver](divide-resolver.md) | *(promoted)* | Divides two numeric or vector values. |
 | [FloorResolver](floor-resolver.md) | *(same)* | Rounds down to the largest integer less than or equal to the operand. |
 | [LerpResolver](lerp-resolver.md) | `float`/`double`/vector/quaternion | Linearly interpolates between two values (scalar, vector, or quaternion). |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -54,6 +54,7 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [PowResolver](pow-resolver.md) | `float`/`double` | Raises a value to a specified power. |
 | [RoundResolver](round-resolver.md) | *(same)* | Rounds to the nearest integer using banker's rounding. |
 | [RadToDegResolver](radtodeg-resolver.md) | `float`/`double` | Converts radians to degrees. |
+| [RandomResolver](random-resolver.md) | `int`/`float`/`double` | Generates a random value in a range using an `IRandom` provider. |
 | [SignResolver](sign-resolver.md) | `int` | Returns -1, 0, or 1 indicating the sign of a numeric value. |
 | [SinHResolver](sinh-resolver.md) | `float`/`double` | Computes the hyperbolic sine. |
 | [SinResolver](sin-resolver.md) | `float`/`double` | Computes the sine of an angle in radians. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -30,6 +30,9 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [ExpResolver](exp-resolver.md) | `float`/`double` | Computes `e` raised to a specified power (`e^x`). |
 | [FloorResolver](floor-resolver.md) | *(same)* | Rounds down to the largest integer less than or equal to the operand. |
 | [LerpResolver](lerp-resolver.md) | `float`/`double`/vector/quaternion | Linearly interpolates between two values (scalar, vector, or quaternion). |
+| [Log10Resolver](log10-resolver.md) | `float`/`double` | Computes the base-10 logarithm. |
+| [Log2Resolver](log2-resolver.md) | `float`/`double` | Computes the base-2 logarithm. |
+| [LogResolver](log-resolver.md) | `float`/`double` | Computes the natural logarithm (base `e`). |
 | [MaxResolver](max-resolver.md) | *(promoted)* | Returns the larger of two numeric values. |
 | [MinResolver](min-resolver.md) | *(promoted)* | Returns the smaller of two numeric values. |
 | [ModuloResolver](modulo-resolver.md) | *(promoted)* | Computes the remainder of dividing two numeric values. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -22,4 +22,5 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | Resolver | Output Type | Description |
 |----------|-------------|-------------|
 | [AddResolver](add-resolver.md) | *(promoted)* | Adds two numeric or vector values. |
+| [MultiplyResolver](multiply-resolver.md) | *(promoted)* | Multiplies two numeric or vector values. |
 | [SubtractResolver](subtract-resolver.md) | *(promoted)* | Subtracts two numeric or vector values. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -16,3 +16,9 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [TagResolver](tag-resolver.md) | `bool` | Checks whether the owner entity has a specific tag. |
 | [VariableResolver](variable-resolver.md) | *(configured)* | Reads a graph variable by name. |
 | [VariantResolver](variant-resolver.md) | *(configured)* | Holds a fixed constant value. |
+
+## Math Resolvers
+
+| Resolver | Output Type | Description |
+|----------|-------------|-------------|
+| [AddResolver](add-resolver.md) | *(promoted)* | Adds two numeric or vector values. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -35,6 +35,7 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [NegateResolver](negate-resolver.md) | *(promoted)* | Negates a numeric or vector value. |
 | [PowResolver](pow-resolver.md) | `float`/`double` | Raises a value to a specified power. |
 | [RoundResolver](round-resolver.md) | *(same)* | Rounds to the nearest integer using banker's rounding. |
+| [SignResolver](sign-resolver.md) | `int` | Returns -1, 0, or 1 indicating the sign of a numeric value. |
 | [SqrtResolver](sqrt-resolver.md) | `float`/`double` | Computes the square root of a numeric value. |
 | [SubtractResolver](subtract-resolver.md) | *(promoted)* | Subtracts two numeric or vector values. |
 | [TruncateResolver](truncate-resolver.md) | *(same)* | Removes the fractional part, rounding toward zero. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -24,6 +24,7 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [AbsResolver](abs-resolver.md) | *(promoted)* | Computes the absolute value of a signed numeric value. |
 | [AddResolver](add-resolver.md) | *(promoted)* | Adds two numeric or vector values. |
 | [CeilResolver](ceil-resolver.md) | *(same)* | Rounds up to the smallest integer greater than or equal to the operand. |
+| [ClampResolver](clamp-resolver.md) | *(promoted)* | Clamps a numeric value between a minimum and maximum bound. |
 | [DivideResolver](divide-resolver.md) | *(promoted)* | Divides two numeric or vector values. |
 | [FloorResolver](floor-resolver.md) | *(same)* | Rounds down to the largest integer less than or equal to the operand. |
 | [LerpResolver](lerp-resolver.md) | `float`/`double`/vector/quaternion | Linearly interpolates between two values (scalar, vector, or quaternion). |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -23,6 +23,7 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 |----------|-------------|-------------|
 | [AbsResolver](abs-resolver.md) | *(promoted)* | Computes the absolute value of a signed numeric value. |
 | [AddResolver](add-resolver.md) | *(promoted)* | Adds two numeric or vector values. |
+| [CbrtResolver](cbrt-resolver.md) | `float`/`double` | Computes the cube root. |
 | [CeilResolver](ceil-resolver.md) | *(same)* | Rounds up to the smallest integer greater than or equal to the operand. |
 | [ClampResolver](clamp-resolver.md) | *(promoted)* | Clamps a numeric value between a minimum and maximum bound. |
 | [DivideResolver](divide-resolver.md) | *(promoted)* | Divides two numeric or vector values. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -28,4 +28,5 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [ModuloResolver](modulo-resolver.md) | *(promoted)* | Computes the remainder of dividing two numeric values. |
 | [MultiplyResolver](multiply-resolver.md) | *(promoted)* | Multiplies two numeric or vector values. |
 | [NegateResolver](negate-resolver.md) | *(promoted)* | Negates a numeric or vector value. |
+| [PowResolver](pow-resolver.md) | `float`/`double` | Raises a value to a specified power. |
 | [SubtractResolver](subtract-resolver.md) | *(promoted)* | Subtracts two numeric or vector values. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -25,4 +25,5 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [DivideResolver](divide-resolver.md) | *(promoted)* | Divides two numeric or vector values. |
 | [ModuloResolver](modulo-resolver.md) | *(promoted)* | Computes the remainder of dividing two numeric values. |
 | [MultiplyResolver](multiply-resolver.md) | *(promoted)* | Multiplies two numeric or vector values. |
+| [NegateResolver](negate-resolver.md) | *(promoted)* | Negates a numeric or vector value. |
 | [SubtractResolver](subtract-resolver.md) | *(promoted)* | Subtracts two numeric or vector values. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -21,6 +21,7 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 
 | Resolver | Output Type | Description |
 |----------|-------------|-------------|
+| [AbsResolver](abs-resolver.md) | *(promoted)* | Computes the absolute value of a signed numeric value. |
 | [AddResolver](add-resolver.md) | *(promoted)* | Adds two numeric or vector values. |
 | [DivideResolver](divide-resolver.md) | *(promoted)* | Divides two numeric or vector values. |
 | [ModuloResolver](modulo-resolver.md) | *(promoted)* | Computes the remainder of dividing two numeric values. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -26,6 +26,7 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [CbrtResolver](cbrt-resolver.md) | `float`/`double` | Computes the cube root. |
 | [CeilResolver](ceil-resolver.md) | *(same)* | Rounds up to the smallest integer greater than or equal to the operand. |
 | [ClampResolver](clamp-resolver.md) | *(promoted)* | Clamps a numeric value between a minimum and maximum bound. |
+| [CosResolver](cos-resolver.md) | `float`/`double` | Computes the cosine of an angle in radians. |
 | [DivideResolver](divide-resolver.md) | *(promoted)* | Divides two numeric or vector values. |
 | [ExpResolver](exp-resolver.md) | `float`/`double` | Computes `e` raised to a specified power (`e^x`). |
 | [FloorResolver](floor-resolver.md) | *(same)* | Rounds down to the largest integer less than or equal to the operand. |
@@ -41,6 +42,8 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [PowResolver](pow-resolver.md) | `float`/`double` | Raises a value to a specified power. |
 | [RoundResolver](round-resolver.md) | *(same)* | Rounds to the nearest integer using banker's rounding. |
 | [SignResolver](sign-resolver.md) | `int` | Returns -1, 0, or 1 indicating the sign of a numeric value. |
+| [SinResolver](sin-resolver.md) | `float`/`double` | Computes the sine of an angle in radians. |
 | [SqrtResolver](sqrt-resolver.md) | `float`/`double` | Computes the square root of a numeric value. |
 | [SubtractResolver](subtract-resolver.md) | *(promoted)* | Subtracts two numeric or vector values. |
+| [TanResolver](tan-resolver.md) | `float`/`double` | Computes the tangent of an angle in radians. |
 | [TruncateResolver](truncate-resolver.md) | *(same)* | Removes the fractional part, rounding toward zero. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -22,10 +22,13 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | Resolver | Output Type | Description |
 |----------|-------------|-------------|
 | [AbsResolver](abs-resolver.md) | *(promoted)* | Computes the absolute value of a signed numeric value. |
+| [ACosHResolver](acosh-resolver.md) | `float`/`double` | Computes the inverse hyperbolic cosine. |
 | [ACosResolver](acos-resolver.md) | `float`/`double` | Computes the arc cosine (inverse cosine), returning angle in radians. |
 | [AddResolver](add-resolver.md) | *(promoted)* | Adds two numeric or vector values. |
+| [ASinHResolver](asinh-resolver.md) | `float`/`double` | Computes the inverse hyperbolic sine. |
 | [ASinResolver](asin-resolver.md) | `float`/`double` | Computes the arc sine (inverse sine), returning angle in radians. |
 | [ATan2Resolver](atan2-resolver.md) | `float`/`double` | Computes the angle from two coordinates using `ATan2(y, x)`. |
+| [ATanHResolver](atanh-resolver.md) | `float`/`double` | Computes the inverse hyperbolic tangent. |
 | [ATanResolver](atan-resolver.md) | `float`/`double` | Computes the arc tangent (inverse tangent), returning angle in radians. |
 | [CbrtResolver](cbrt-resolver.md) | `float`/`double` | Computes the cube root. |
 | [CeilResolver](ceil-resolver.md) | *(same)* | Rounds up to the smallest integer greater than or equal to the operand. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -25,6 +25,7 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [AddResolver](add-resolver.md) | *(promoted)* | Adds two numeric or vector values. |
 | [DivideResolver](divide-resolver.md) | *(promoted)* | Divides two numeric or vector values. |
 | [LerpResolver](lerp-resolver.md) | `float`/`double`/vector/quaternion | Linearly interpolates between two values (scalar, vector, or quaternion). |
+| [MaxResolver](max-resolver.md) | *(promoted)* | Returns the larger of two numeric values. |
 | [MinResolver](min-resolver.md) | *(promoted)* | Returns the smaller of two numeric values. |
 | [ModuloResolver](modulo-resolver.md) | *(promoted)* | Computes the remainder of dividing two numeric values. |
 | [MultiplyResolver](multiply-resolver.md) | *(promoted)* | Multiplies two numeric or vector values. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -34,5 +34,6 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [MultiplyResolver](multiply-resolver.md) | *(promoted)* | Multiplies two numeric or vector values. |
 | [NegateResolver](negate-resolver.md) | *(promoted)* | Negates a numeric or vector value. |
 | [PowResolver](pow-resolver.md) | `float`/`double` | Raises a value to a specified power. |
+| [RoundResolver](round-resolver.md) | *(same)* | Rounds to the nearest integer using banker's rounding. |
 | [SqrtResolver](sqrt-resolver.md) | `float`/`double` | Computes the square root of a numeric value. |
 | [SubtractResolver](subtract-resolver.md) | *(promoted)* | Subtracts two numeric or vector values. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -37,3 +37,4 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [RoundResolver](round-resolver.md) | *(same)* | Rounds to the nearest integer using banker's rounding. |
 | [SqrtResolver](sqrt-resolver.md) | `float`/`double` | Computes the square root of a numeric value. |
 | [SubtractResolver](subtract-resolver.md) | *(promoted)* | Subtracts two numeric or vector values. |
+| [TruncateResolver](truncate-resolver.md) | *(same)* | Removes the fractional part, rounding toward zero. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -23,5 +23,6 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 |----------|-------------|-------------|
 | [AddResolver](add-resolver.md) | *(promoted)* | Adds two numeric or vector values. |
 | [DivideResolver](divide-resolver.md) | *(promoted)* | Divides two numeric or vector values. |
+| [ModuloResolver](modulo-resolver.md) | *(promoted)* | Computes the remainder of dividing two numeric values. |
 | [MultiplyResolver](multiply-resolver.md) | *(promoted)* | Multiplies two numeric or vector values. |
 | [SubtractResolver](subtract-resolver.md) | *(promoted)* | Subtracts two numeric or vector values. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -27,6 +27,7 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [CeilResolver](ceil-resolver.md) | *(same)* | Rounds up to the smallest integer greater than or equal to the operand. |
 | [ClampResolver](clamp-resolver.md) | *(promoted)* | Clamps a numeric value between a minimum and maximum bound. |
 | [DivideResolver](divide-resolver.md) | *(promoted)* | Divides two numeric or vector values. |
+| [ExpResolver](exp-resolver.md) | `float`/`double` | Computes `e` raised to a specified power (`e^x`). |
 | [FloorResolver](floor-resolver.md) | *(same)* | Rounds down to the largest integer less than or equal to the operand. |
 | [LerpResolver](lerp-resolver.md) | `float`/`double`/vector/quaternion | Linearly interpolates between two values (scalar, vector, or quaternion). |
 | [MaxResolver](max-resolver.md) | *(promoted)* | Returns the larger of two numeric values. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -37,6 +37,7 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [CosHResolver](cosh-resolver.md) | `float`/`double` | Computes the hyperbolic cosine. |
 | [CosResolver](cos-resolver.md) | `float`/`double` | Computes the cosine of an angle in radians. |
 | [DivideResolver](divide-resolver.md) | *(promoted)* | Divides two numeric or vector values. |
+| [EResolver](e-resolver.md) | `float`/`double` | Returns the mathematical constant `e` (Euler's number). |
 | [ExpResolver](exp-resolver.md) | `float`/`double` | Computes `e` raised to a specified power (`e^x`). |
 | [FloorResolver](floor-resolver.md) | *(same)* | Rounds down to the largest integer less than or equal to the operand. |
 | [LerpResolver](lerp-resolver.md) | `float`/`double`/vector/quaternion | Linearly interpolates between two values (scalar, vector, or quaternion). |
@@ -48,6 +49,7 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [ModuloResolver](modulo-resolver.md) | *(promoted)* | Computes the remainder of dividing two numeric values. |
 | [MultiplyResolver](multiply-resolver.md) | *(promoted)* | Multiplies two numeric or vector values. |
 | [NegateResolver](negate-resolver.md) | *(promoted)* | Negates a numeric or vector value. |
+| [PiResolver](pi-resolver.md) | `float`/`double` | Returns the mathematical constant π (pi). |
 | [PowResolver](pow-resolver.md) | `float`/`double` | Raises a value to a specified power. |
 | [RoundResolver](round-resolver.md) | *(same)* | Rounds to the nearest integer using banker's rounding. |
 | [SignResolver](sign-resolver.md) | `int` | Returns -1, 0, or 1 indicating the sign of a numeric value. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -24,6 +24,7 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [AbsResolver](abs-resolver.md) | *(promoted)* | Computes the absolute value of a signed numeric value. |
 | [AddResolver](add-resolver.md) | *(promoted)* | Adds two numeric or vector values. |
 | [DivideResolver](divide-resolver.md) | *(promoted)* | Divides two numeric or vector values. |
+| [FloorResolver](floor-resolver.md) | *(same)* | Rounds down to the largest integer less than or equal to the operand. |
 | [LerpResolver](lerp-resolver.md) | `float`/`double`/vector/quaternion | Linearly interpolates between two values (scalar, vector, or quaternion). |
 | [MaxResolver](max-resolver.md) | *(promoted)* | Returns the larger of two numeric values. |
 | [MinResolver](min-resolver.md) | *(promoted)* | Returns the smaller of two numeric values. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -29,4 +29,5 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [MultiplyResolver](multiply-resolver.md) | *(promoted)* | Multiplies two numeric or vector values. |
 | [NegateResolver](negate-resolver.md) | *(promoted)* | Negates a numeric or vector value. |
 | [PowResolver](pow-resolver.md) | `float`/`double` | Raises a value to a specified power. |
+| [SqrtResolver](sqrt-resolver.md) | `float`/`double` | Computes the square root of a numeric value. |
 | [SubtractResolver](subtract-resolver.md) | *(promoted)* | Subtracts two numeric or vector values. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -52,9 +52,9 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [NegateResolver](negate-resolver.md) | *(promoted)* | Negates a numeric or vector value. |
 | [PiResolver](pi-resolver.md) | `float`/`double` | Returns the mathematical constant π (pi). |
 | [PowResolver](pow-resolver.md) | `float`/`double` | Raises a value to a specified power. |
-| [RoundResolver](round-resolver.md) | *(same)* | Rounds to the nearest integer using banker's rounding. |
 | [RadToDegResolver](radtodeg-resolver.md) | `float`/`double` | Converts radians to degrees. |
 | [RandomResolver](random-resolver.md) | `int`/`float`/`double` | Generates a random value in a range using an `IRandom` provider. |
+| [RoundResolver](round-resolver.md) | *(same)* | Rounds to a specified number of digits with configurable rounding mode. |
 | [SignResolver](sign-resolver.md) | `int` | Returns -1, 0, or 1 indicating the sign of a numeric value. |
 | [SinHResolver](sinh-resolver.md) | `float`/`double` | Computes the hyperbolic sine. |
 | [SinResolver](sin-resolver.md) | `float`/`double` | Computes the sine of an angle in radians. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -22,3 +22,4 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | Resolver | Output Type | Description |
 |----------|-------------|-------------|
 | [AddResolver](add-resolver.md) | *(promoted)* | Adds two numeric or vector values. |
+| [SubtractResolver](subtract-resolver.md) | *(promoted)* | Subtracts two numeric or vector values. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -22,7 +22,11 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | Resolver | Output Type | Description |
 |----------|-------------|-------------|
 | [AbsResolver](abs-resolver.md) | *(promoted)* | Computes the absolute value of a signed numeric value. |
+| [ACosResolver](acos-resolver.md) | `float`/`double` | Computes the arc cosine (inverse cosine), returning angle in radians. |
 | [AddResolver](add-resolver.md) | *(promoted)* | Adds two numeric or vector values. |
+| [ASinResolver](asin-resolver.md) | `float`/`double` | Computes the arc sine (inverse sine), returning angle in radians. |
+| [ATan2Resolver](atan2-resolver.md) | `float`/`double` | Computes the angle from two coordinates using `ATan2(y, x)`. |
+| [ATanResolver](atan-resolver.md) | `float`/`double` | Computes the arc tangent (inverse tangent), returning angle in radians. |
 | [CbrtResolver](cbrt-resolver.md) | `float`/`double` | Computes the cube root. |
 | [CeilResolver](ceil-resolver.md) | *(same)* | Rounds up to the smallest integer greater than or equal to the operand. |
 | [ClampResolver](clamp-resolver.md) | *(promoted)* | Clamps a numeric value between a minimum and maximum bound. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -22,5 +22,6 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | Resolver | Output Type | Description |
 |----------|-------------|-------------|
 | [AddResolver](add-resolver.md) | *(promoted)* | Adds two numeric or vector values. |
+| [DivideResolver](divide-resolver.md) | *(promoted)* | Divides two numeric or vector values. |
 | [MultiplyResolver](multiply-resolver.md) | *(promoted)* | Multiplies two numeric or vector values. |
 | [SubtractResolver](subtract-resolver.md) | *(promoted)* | Subtracts two numeric or vector values. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -36,6 +36,7 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [CopySignResolver](copysign-resolver.md) | `float`/`double` | Returns a value with the magnitude of one operand and the sign of another. |
 | [CosHResolver](cosh-resolver.md) | `float`/`double` | Computes the hyperbolic cosine. |
 | [CosResolver](cos-resolver.md) | `float`/`double` | Computes the cosine of an angle in radians. |
+| [DegToRadResolver](degtorad-resolver.md) | `float`/`double` | Converts degrees to radians. |
 | [DivideResolver](divide-resolver.md) | *(promoted)* | Divides two numeric or vector values. |
 | [EResolver](e-resolver.md) | `float`/`double` | Returns the mathematical constant `e` (Euler's number). |
 | [ExpResolver](exp-resolver.md) | `float`/`double` | Computes `e` raised to a specified power (`e^x`). |
@@ -52,6 +53,7 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [PiResolver](pi-resolver.md) | `float`/`double` | Returns the mathematical constant π (pi). |
 | [PowResolver](pow-resolver.md) | `float`/`double` | Raises a value to a specified power. |
 | [RoundResolver](round-resolver.md) | *(same)* | Rounds to the nearest integer using banker's rounding. |
+| [RadToDegResolver](radtodeg-resolver.md) | `float`/`double` | Converts radians to degrees. |
 | [SignResolver](sign-resolver.md) | `int` | Returns -1, 0, or 1 indicating the sign of a numeric value. |
 | [SinHResolver](sinh-resolver.md) | `float`/`double` | Computes the hyperbolic sine. |
 | [SinResolver](sin-resolver.md) | `float`/`double` | Computes the sine of an angle in radians. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -26,6 +26,7 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [CbrtResolver](cbrt-resolver.md) | `float`/`double` | Computes the cube root. |
 | [CeilResolver](ceil-resolver.md) | *(same)* | Rounds up to the smallest integer greater than or equal to the operand. |
 | [ClampResolver](clamp-resolver.md) | *(promoted)* | Clamps a numeric value between a minimum and maximum bound. |
+| [CosHResolver](cosh-resolver.md) | `float`/`double` | Computes the hyperbolic cosine. |
 | [CosResolver](cos-resolver.md) | `float`/`double` | Computes the cosine of an angle in radians. |
 | [DivideResolver](divide-resolver.md) | *(promoted)* | Divides two numeric or vector values. |
 | [ExpResolver](exp-resolver.md) | `float`/`double` | Computes `e` raised to a specified power (`e^x`). |
@@ -42,8 +43,10 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [PowResolver](pow-resolver.md) | `float`/`double` | Raises a value to a specified power. |
 | [RoundResolver](round-resolver.md) | *(same)* | Rounds to the nearest integer using banker's rounding. |
 | [SignResolver](sign-resolver.md) | `int` | Returns -1, 0, or 1 indicating the sign of a numeric value. |
+| [SinHResolver](sinh-resolver.md) | `float`/`double` | Computes the hyperbolic sine. |
 | [SinResolver](sin-resolver.md) | `float`/`double` | Computes the sine of an angle in radians. |
 | [SqrtResolver](sqrt-resolver.md) | `float`/`double` | Computes the square root of a numeric value. |
 | [SubtractResolver](subtract-resolver.md) | *(promoted)* | Subtracts two numeric or vector values. |
+| [TanHResolver](tanh-resolver.md) | `float`/`double` | Computes the hyperbolic tangent. |
 | [TanResolver](tan-resolver.md) | `float`/`double` | Computes the tangent of an angle in radians. |
 | [TruncateResolver](truncate-resolver.md) | *(same)* | Removes the fractional part, rounding toward zero. |

--- a/docs/statescript/resolvers/abs-resolver.md
+++ b/docs/statescript/resolvers/abs-resolver.md
@@ -1,0 +1,72 @@
+# AbsResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.AbsResolver`
+> **Output Type:** *(same as operand, promoted for sub-int types)*
+
+Computes the absolute value of a single operand. Supports all **signed** numeric types in `Variant128`: `sbyte`, `short`, `int`, `long`, `float`, `double`, and `decimal`. Unsigned types, vector types, and quaternion types are not supported (absolute value is meaningless for unsigned types and has no standard definition for vectors/quaternions).
+
+## Constructor
+
+```csharp
+new AbsResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand. |
+
+## Type Promotion
+
+The result type matches the operand type, with sub-int types promoted to `int`. Only **signed** numeric types are supported:
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `sbyte`, `short` | `int` |
+| `int` | `int` |
+| `long` | `long` |
+| `float` | `float` |
+| `double` | `double` |
+| `decimal` | `decimal` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `byte`, `ushort`, `uint`, `ulong` (unsigned, absolute value is identity).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Applies `Math.Abs` and returns the result as a `Variant128`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Distance is always positive
+graph.VariableDefinitions.DefineProperty("distance",
+    new AbsResolver(
+        new SubtractResolver(
+            new VariableResolver("positionA", typeof(int)),
+            new VariableResolver("positionB", typeof(int)))));
+```
+
+## Composition
+
+```csharp
+// Check if two positions are within threshold distance:
+// Abs(a - b) < threshold
+graph.VariableDefinitions.DefineProperty("isInRange",
+    new ComparisonResolver(
+        new AbsResolver(
+            new SubtractResolver(
+                new VariableResolver("positionA", typeof(float)),
+                new VariableResolver("positionB", typeof(float)))),
+        ComparisonOperation.LessThan,
+        new VariantResolver(new Variant128(5.0f), typeof(float))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [NegateResolver](negate-resolver.md)
+- [ComparisonResolver](comparison-resolver.md)

--- a/docs/statescript/resolvers/acos-resolver.md
+++ b/docs/statescript/resolvers/acos-resolver.md
@@ -1,0 +1,44 @@
+# ACosResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.ACosResolver`
+> **Output Type:** `float` or `double`
+
+Computes the arc cosine (inverse cosine) of an operand, returning the angle in radians. Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new ACosResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand (value in the range [-1, 1]). |
+
+## Type Promotion
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `float` | `float` |
+| `double` | `double` |
+| Any integer type | `double` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `decimal` (use `double` instead).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Computes `Math.Acos` (or `MathF.Acos` for `float`) and returns the result as a `Variant128`.
+- `ACos(1) = 0`, `ACos(0) = π/2`, `ACos(-1) = π`.
+- Values outside `[-1, 1]` produce `NaN`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [CosResolver](cos-resolver.md)
+- [ASinResolver](asin-resolver.md)
+- [ACosHResolver](acosh-resolver.md)

--- a/docs/statescript/resolvers/acosh-resolver.md
+++ b/docs/statescript/resolvers/acosh-resolver.md
@@ -1,0 +1,43 @@
+# ACosHResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.ACosHResolver`
+> **Output Type:** `float` or `double`
+
+Computes the inverse hyperbolic cosine of an operand. Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new ACosHResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand (value ≥ 1). |
+
+## Type Promotion
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `float` | `float` |
+| `double` | `double` |
+| Any integer type | `double` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `decimal` (use `double` instead).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Computes `Math.Acosh` (or `MathF.Acosh` for `float`) and returns the result as a `Variant128`.
+- `ACosH(1) = 0`.
+- Values less than `1` produce `NaN`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [CosHResolver](cosh-resolver.md)
+- [ACosResolver](acos-resolver.md)

--- a/docs/statescript/resolvers/add-resolver.md
+++ b/docs/statescript/resolvers/add-resolver.md
@@ -39,16 +39,16 @@ When operands differ, the wider numeric type wins:
 
 | Mixed Operands | Result Type |
 |----------------|-------------|
-| `int` + `float` | `float` |
-| `int` + `double` | `double` |
-| `float` + `double` | `double` |
-| `byte` + `int` | `int` |
-| `short` + `long` | `long` |
-| `int` + `decimal` | `decimal` |
+| `int + float` | `float` |
+| `int + double` | `double` |
+| `float + double` | `double` |
+| `byte + int` | `int` |
+| `short + long` | `long` |
+| `int + decimal` | `decimal` |
 
 **Invalid combinations** (throw `ArgumentException` at construction time):
-- Mixing vector/quaternion types (e.g., `Vector2` + `Vector3`).
-- Mixing vector/quaternion with numeric types (e.g., `Vector3` + `float`).
+- Mixing vector/quaternion types (e.g., `Vector2 + Vector3`).
+- Mixing vector/quaternion with numeric types (e.g., `Vector3 + float`).
 - Unsupported types (`bool`, `char`).
 
 ## Behavior

--- a/docs/statescript/resolvers/add-resolver.md
+++ b/docs/statescript/resolvers/add-resolver.md
@@ -1,0 +1,105 @@
+# AddResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.AddResolver`
+> **Output Type:** *(promoted from operand types)*
+
+Adds two numeric or vector values. Supports all numeric types in `Variant128` as well as `Vector2`, `Vector3`, `Vector4`, and `Quaternion`. When the two operands have different numeric types, standard numeric promotion rules apply.
+
+## Constructor
+
+```csharp
+new AddResolver(left, right)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| left | `IPropertyResolver` | The resolver for the left operand. |
+| right | `IPropertyResolver` | The resolver for the right operand. |
+
+## Type Promotion
+
+When both operands have the same type, the result type is determined by promotion rules that mirror C# arithmetic:
+
+| Operand Types | Result Type |
+|---------------|-------------|
+| `byte`, `sbyte`, `short`, `ushort` | `int` |
+| `int` | `int` |
+| `uint` | `long` |
+| `long` | `long` |
+| `ulong` | `double` |
+| `float` | `float` |
+| `double` | `double` |
+| `decimal` | `decimal` |
+| `Vector2` | `Vector2` |
+| `Vector3` | `Vector3` |
+| `Vector4` | `Vector4` |
+| `Quaternion` | `Quaternion` |
+
+When operands differ, the wider numeric type wins:
+
+| Mixed Operands | Result Type |
+|----------------|-------------|
+| `int` + `float` | `float` |
+| `int` + `double` | `double` |
+| `float` + `double` | `double` |
+| `byte` + `int` | `int` |
+| `short` + `long` | `long` |
+| `int` + `decimal` | `decimal` |
+
+**Invalid combinations** (throw `ArgumentException` at construction time):
+- Mixing vector/quaternion types (e.g., `Vector2` + `Vector3`).
+- Mixing vector/quaternion with numeric types (e.g., `Vector3` + `float`).
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves both operands through their respective `IPropertyResolver` instances.
+- Converts each operand to the promoted result type.
+- Performs the addition and returns the result as a `Variant128`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Add two integer variables
+graph.VariableDefinitions.DefineProperty("totalDamage",
+    new AddResolver(
+        new VariableResolver("baseDamage", typeof(int)),
+        new VariableResolver("bonusDamage", typeof(int))));
+
+// Add two Vector3 positions
+graph.VariableDefinitions.DefineProperty("offsetPosition",
+    new AddResolver(
+        new VariableResolver("position", typeof(Vector3)),
+        new VariableResolver("offset", typeof(Vector3))));
+```
+
+## Composition
+
+AddResolver is nestable and composes with all other resolvers:
+
+```csharp
+// Chain: (baseDamage + bonusDamage) + critBonus
+graph.VariableDefinitions.DefineProperty("finalDamage",
+    new AddResolver(
+        new AddResolver(
+            new VariableResolver("baseDamage", typeof(int)),
+            new VariableResolver("bonusDamage", typeof(int))),
+        new VariableResolver("critBonus", typeof(int))));
+
+// Compose with ComparisonResolver: (a + b) > threshold
+graph.VariableDefinitions.DefineProperty("isOverThreshold",
+    new ComparisonResolver(
+        new AddResolver(
+            new VariableResolver("valueA", typeof(int)),
+            new VariableResolver("valueB", typeof(int))),
+        ComparisonOperation.GreaterThan,
+        new VariantResolver(new Variant128(100), typeof(int))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [ComparisonResolver](comparison-resolver.md)
+- [VariableResolver](variable-resolver.md)
+- [VariantResolver](variant-resolver.md)

--- a/docs/statescript/resolvers/array-resolver.md
+++ b/docs/statescript/resolvers/array-resolver.md
@@ -41,6 +41,17 @@ resolver.RemoveAt(0);
 resolver.Clear();
 ```
 
+## Composition
+
+```csharp
+// Compare the first element of an array against a threshold
+graph.VariableDefinitions.DefineProperty("firstEnemyClose",
+    new ComparisonResolver(
+        myArrayResolver,
+        ComparisonOperation.LessThan,
+        new VariantResolver(new Variant128(10.0f), typeof(float))));
+```
+
 ## See Also
 
 - [Resolvers Overview](README.md)

--- a/docs/statescript/resolvers/asin-resolver.md
+++ b/docs/statescript/resolvers/asin-resolver.md
@@ -1,0 +1,44 @@
+# ASinResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.ASinResolver`
+> **Output Type:** `float` or `double`
+
+Computes the arc sine (inverse sine) of an operand, returning the angle in radians. Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new ASinResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand (value in the range [-1, 1]). |
+
+## Type Promotion
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `float` | `float` |
+| `double` | `double` |
+| Any integer type | `double` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `decimal` (use `double` instead).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Computes `Math.Asin` (or `MathF.Asin` for `float`) and returns the result as a `Variant128`.
+- `ASin(0) = 0`, `ASin(1) = π/2`, `ASin(-1) = -π/2`.
+- Values outside `[-1, 1]` produce `NaN`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [SinResolver](sin-resolver.md)
+- [ACosResolver](acos-resolver.md)
+- [ASinHResolver](asinh-resolver.md)

--- a/docs/statescript/resolvers/asinh-resolver.md
+++ b/docs/statescript/resolvers/asinh-resolver.md
@@ -1,0 +1,42 @@
+# ASinHResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.ASinHResolver`
+> **Output Type:** `float` or `double`
+
+Computes the inverse hyperbolic sine of an operand. Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new ASinHResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand. |
+
+## Type Promotion
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `float` | `float` |
+| `double` | `double` |
+| Any integer type | `double` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `decimal` (use `double` instead).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Computes `Math.Asinh` (or `MathF.Asinh` for `float`) and returns the result as a `Variant128`.
+- `ASinH(0) = 0`. ASinH is an odd function.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [SinHResolver](sinh-resolver.md)
+- [ASinResolver](asin-resolver.md)

--- a/docs/statescript/resolvers/atan-resolver.md
+++ b/docs/statescript/resolvers/atan-resolver.md
@@ -1,0 +1,43 @@
+# ATanResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.ATanResolver`
+> **Output Type:** `float` or `double`
+
+Computes the arc tangent (inverse tangent) of an operand, returning the angle in radians. Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new ATanResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand. |
+
+## Type Promotion
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `float` | `float` |
+| `double` | `double` |
+| Any integer type | `double` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `decimal` (use `double` instead).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Computes `Math.Atan` (or `MathF.Atan` for `float`) and returns the result as a `Variant128`.
+- `ATan(0) = 0`, `ATan(1) = π/4`, `ATan(-1) = -π/4`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [TanResolver](tan-resolver.md)
+- [ATan2Resolver](atan2-resolver.md)
+- [ATanHResolver](atanh-resolver.md)

--- a/docs/statescript/resolvers/atan2-resolver.md
+++ b/docs/statescript/resolvers/atan2-resolver.md
@@ -1,0 +1,59 @@
+# ATan2Resolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.ATan2Resolver`
+> **Output Type:** `float` or `double`
+
+Computes the angle (in radians) whose tangent is the quotient of two operands: `ATan2(y, x)`. This is the standard two-argument arc tangent that correctly handles all four quadrants. Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new ATan2Resolver(y, x)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| y | `IPropertyResolver` | The resolver for the y-coordinate operand. |
+| x | `IPropertyResolver` | The resolver for the x-coordinate operand. |
+
+## Type Promotion
+
+| Operand Types | Result Type |
+|---------------|-------------|
+| Both `float` | `float` |
+| Any `double` | `double` |
+| Any integer type | `double` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `decimal` (use `double` instead).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves both operands through their respective `IPropertyResolver` instances.
+- Computes `Math.Atan2(y, x)` (or `MathF.Atan2` for `float`) and returns the result as a `Variant128`.
+- Returns values in the range `(-π, π]`.
+- `ATan2(0, 1) = 0`, `ATan2(1, 0) = π/2`, `ATan2(1, 1) = π/4`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Compute angle to target for aiming
+graph.VariableDefinitions.DefineProperty("angleToTarget",
+    new ATan2Resolver(
+        new SubtractResolver(
+            new VariableResolver("targetY", typeof(double)),
+            new VariableResolver("currentY", typeof(double))),
+        new SubtractResolver(
+            new VariableResolver("targetX", typeof(double)),
+            new VariableResolver("currentX", typeof(double)))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [ATanResolver](atan-resolver.md)
+- [SinResolver](sin-resolver.md)
+- [CosResolver](cos-resolver.md)

--- a/docs/statescript/resolvers/atanh-resolver.md
+++ b/docs/statescript/resolvers/atanh-resolver.md
@@ -1,0 +1,43 @@
+# ATanHResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.ATanHResolver`
+> **Output Type:** `float` or `double`
+
+Computes the inverse hyperbolic tangent of an operand. Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new ATanHResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand (value in the range (-1, 1)). |
+
+## Type Promotion
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `float` | `float` |
+| `double` | `double` |
+| Any integer type | `double` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `decimal` (use `double` instead).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Computes `Math.Atanh` (or `MathF.Atanh` for `float`) and returns the result as a `Variant128`.
+- `ATanH(0) = 0`. ATanH is an odd function.
+- Values at `±1` produce `±∞`. Values outside `(-1, 1)` produce `NaN`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [TanHResolver](tanh-resolver.md)
+- [ATanResolver](atan-resolver.md)

--- a/docs/statescript/resolvers/cbrt-resolver.md
+++ b/docs/statescript/resolvers/cbrt-resolver.md
@@ -1,0 +1,52 @@
+# CbrtResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.CbrtResolver`
+> **Output Type:** `float` or `double`
+
+Computes the cube root of an operand. Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new CbrtResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand. |
+
+## Type Promotion
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `float` | `float` |
+| `double` | `double` |
+| Any integer type | `double` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `decimal` (use `double` instead).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Computes `Math.Cbrt` (or `MathF.Cbrt` for `float`) and returns the result as a `Variant128`.
+- `Cbrt(0) = 0`, `Cbrt(1) = 1`, `Cbrt(27) = 3`.
+- Unlike `Sqrt`, cube root handles negative values: `Cbrt(-8) = -2`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Convert volume to side length of a cube
+graph.VariableDefinitions.DefineProperty("sideLength",
+    new CbrtResolver(
+        new VariableResolver("volume", typeof(double))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [SqrtResolver](sqrt-resolver.md)
+- [PowResolver](pow-resolver.md)

--- a/docs/statescript/resolvers/ceil-resolver.md
+++ b/docs/statescript/resolvers/ceil-resolver.md
@@ -1,0 +1,68 @@
+# CeilResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.CeilResolver`
+> **Output Type:** *(same as operand type)*
+
+Computes the smallest integer greater than or equal to the operand (ceiling). Only `float`, `double`, and `decimal` types are supported. Integer, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new CeilResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand. |
+
+## Type Promotion
+
+The result type matches the operand type exactly:
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `float` | `float` |
+| `double` | `double` |
+| `decimal` | `decimal` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `int`, `long`, and all other integer types (ceiling is identity for integers).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Applies `Math.Ceiling` (or `MathF.Ceiling` for `float`) and returns the result as a `Variant128`.
+- For positive values, rounds up: `Ceil(2.3) = 3.0`.
+- For negative values, rounds toward zero: `Ceil(-2.7) = -2.0`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Always round up resource requirements
+graph.VariableDefinitions.DefineProperty("requiredItems",
+    new CeilResolver(
+        new DivideResolver(
+            new VariableResolver("totalCost", typeof(double)),
+            new VariableResolver("costPerItem", typeof(double)))));
+```
+
+## Composition
+
+```csharp
+// Minimum number of hits to defeat an enemy (always round up)
+graph.VariableDefinitions.DefineProperty("hitsRequired",
+    new CeilResolver(
+        new DivideResolver(
+            new VariableResolver("enemyHealth", typeof(float)),
+            new VariableResolver("damagePerHit", typeof(float)))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [FloorResolver](floor-resolver.md)
+- [RoundResolver](round-resolver.md)
+- [TruncateResolver](truncate-resolver.md)

--- a/docs/statescript/resolvers/clamp-resolver.md
+++ b/docs/statescript/resolvers/clamp-resolver.md
@@ -1,0 +1,81 @@
+# ClampResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.ClampResolver`
+> **Output Type:** *(promoted from operand types)*
+
+Clamps a value between a minimum and maximum bound. Supports all numeric types in `Variant128`. Vector and quaternion types are not supported. When operands have different numeric types, standard numeric promotion rules apply across all three operands.
+
+## Constructor
+
+```csharp
+new ClampResolver(value, min, max)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| value | `IPropertyResolver` | The resolver for the value to clamp. |
+| min | `IPropertyResolver` | The resolver for the minimum bound. |
+| max | `IPropertyResolver` | The resolver for the maximum bound. |
+
+## Type Promotion
+
+The result type is determined by promoting all three operand types using standard C# numeric promotion rules:
+
+| Operand Types | Result Type |
+|---------------|-------------|
+| `byte`, `sbyte`, `short`, `ushort` | `int` |
+| `int` | `int` |
+| `uint` | `long` |
+| `long` | `long` |
+| `ulong` | `double` |
+| `float` | `float` |
+| `double` | `double` |
+| `decimal` | `decimal` |
+
+When operands differ, the widest numeric type wins.
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves all three operands through their respective `IPropertyResolver` instances.
+- Converts each operand to the promoted result type.
+- Returns `Math.Clamp(value, min, max)` as a `Variant128`.
+- If `value` is within `[min, max]`, returns `value` unchanged.
+- If `value < min`, returns `min`.
+- If `value > max`, returns `max`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Clamp health between 0 and maxHealth after taking damage
+graph.VariableDefinitions.DefineProperty("currentHealth",
+    new ClampResolver(
+        new SubtractResolver(
+            new VariableResolver("health", typeof(int)),
+            new VariableResolver("damage", typeof(int))),
+        new VariantResolver(new Variant128(0), typeof(int)),
+        new VariableResolver("maxHealth", typeof(int))));
+```
+
+## Composition
+
+```csharp
+// Clamp a multiplier between 0.5 and 2.0 based on computed value
+graph.VariableDefinitions.DefineProperty("effectiveMultiplier",
+    new ClampResolver(
+        new DivideResolver(
+            new VariableResolver("power", typeof(float)),
+            new VariableResolver("baseline", typeof(float))),
+        new VariantResolver(new Variant128(0.5f), typeof(float)),
+        new VariantResolver(new Variant128(2.0f), typeof(float))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [MinResolver](min-resolver.md)
+- [MaxResolver](max-resolver.md)

--- a/docs/statescript/resolvers/copysign-resolver.md
+++ b/docs/statescript/resolvers/copysign-resolver.md
@@ -1,0 +1,54 @@
+# CopySignResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.CopySignResolver`
+> **Output Type:** `float` or `double`
+
+Returns a value with the magnitude of the first operand and the sign of the second operand. Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new CopySignResolver(magnitude, sign)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| magnitude | `IPropertyResolver` | The resolver for the magnitude operand. |
+| sign | `IPropertyResolver` | The resolver for the sign operand. |
+
+## Type Promotion
+
+| Operand Types | Result Type |
+|---------------|-------------|
+| Both `float` | `float` |
+| Any `double` | `double` |
+| Any integer type | `double` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `decimal` (use `double` instead).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves both operands through their respective `IPropertyResolver` instances.
+- Returns `|magnitude|` with the sign of `sign`.
+- `CopySign(5, -3) = -5`, `CopySign(-5, 3) = 5`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Apply direction to a speed value
+graph.VariableDefinitions.DefineProperty("directedSpeed",
+    new CopySignResolver(
+        new AbsResolver(
+            new VariableResolver("speed", typeof(float))),
+        new VariableResolver("direction", typeof(float))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [SignResolver](sign-resolver.md)
+- [AbsResolver](abs-resolver.md)

--- a/docs/statescript/resolvers/cos-resolver.md
+++ b/docs/statescript/resolvers/cos-resolver.md
@@ -1,0 +1,54 @@
+# CosResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.CosResolver`
+> **Output Type:** `float` or `double`
+
+Computes the cosine of an operand (in radians). Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new CosResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand (angle in radians). |
+
+## Type Promotion
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `float` | `float` |
+| `double` | `double` |
+| Any integer type | `double` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `decimal` (use `double` instead).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Computes `Math.Cos` (or `MathF.Cos` for `float`) and returns the result as a `Variant128`.
+- `Cos(0) = 1`, `Cos(π/2) = 0`, `Cos(π) = -1`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Horizontal component of a directional force
+graph.VariableDefinitions.DefineProperty("forceX",
+    new MultiplyResolver(
+        new VariableResolver("forceMagnitude", typeof(float)),
+        new CosResolver(
+            new VariableResolver("angle", typeof(float)))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [SinResolver](sin-resolver.md)
+- [TanResolver](tan-resolver.md)
+- [ACosResolver](acos-resolver.md)

--- a/docs/statescript/resolvers/cosh-resolver.md
+++ b/docs/statescript/resolvers/cosh-resolver.md
@@ -1,0 +1,43 @@
+# CosHResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.CosHResolver`
+> **Output Type:** `float` or `double`
+
+Computes the hyperbolic cosine of an operand. Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new CosHResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand. |
+
+## Type Promotion
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `float` | `float` |
+| `double` | `double` |
+| Any integer type | `double` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `decimal` (use `double` instead).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Computes `Math.Cosh` (or `MathF.Cosh` for `float`) and returns the result as a `Variant128`.
+- `CosH(0) = 1`. CosH is an even function: `CosH(-x) = CosH(x)`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [SinHResolver](sinh-resolver.md)
+- [TanHResolver](tanh-resolver.md)
+- [ACosHResolver](acosh-resolver.md)

--- a/docs/statescript/resolvers/degtorad-resolver.md
+++ b/docs/statescript/resolvers/degtorad-resolver.md
@@ -1,0 +1,53 @@
+# DegToRadResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.DegToRadResolver`
+> **Output Type:** `float` or `double`
+
+Converts an angle from degrees to radians. Computes `degrees * (π / 180)`. Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new DegToRadResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand (angle in degrees). |
+
+## Type Promotion
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `float` | `float` |
+| `double` | `double` |
+| Any integer type | `double` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `decimal` (use `double` instead).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Multiplies the value by `π / 180` and returns the result as a `Variant128`.
+- `DegToRad(0) = 0`, `DegToRad(90) = π/2`, `DegToRad(180) = π`, `DegToRad(360) = 2π`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Use degrees with trig functions that expect radians
+graph.VariableDefinitions.DefineProperty("sinOfAngle",
+    new SinResolver(
+        new DegToRadResolver(
+            new VariableResolver("angleDegrees", typeof(double)))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [RadToDegResolver](radtodeg-resolver.md)
+- [SinResolver](sin-resolver.md)
+- [CosResolver](cos-resolver.md)

--- a/docs/statescript/resolvers/divide-resolver.md
+++ b/docs/statescript/resolvers/divide-resolver.md
@@ -1,0 +1,93 @@
+# DivideResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.DivideResolver`
+> **Output Type:** *(promoted from operand types)*
+
+Divides the left operand by the right operand. Supports all numeric types in `Variant128` as well as `Vector2`, `Vector3`, and `Vector4` (component-wise division). `Quaternion` is not supported.
+
+## Constructor
+
+```csharp
+new DivideResolver(left, right)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| left | `IPropertyResolver` | The resolver for the left (dividend) operand. |
+| right | `IPropertyResolver` | The resolver for the right (divisor) operand. |
+
+## Type Promotion
+
+When both operands have the same type, the result type is determined by promotion rules that mirror C# arithmetic:
+
+| Operand Types | Result Type |
+|---------------|-------------|
+| `byte`, `sbyte`, `short`, `ushort` | `int` |
+| `int` | `int` |
+| `uint` | `long` |
+| `long` | `long` |
+| `ulong` | `double` |
+| `float` | `float` |
+| `double` | `double` |
+| `decimal` | `decimal` |
+| `Vector2` | `Vector2` |
+| `Vector3` | `Vector3` |
+| `Vector4` | `Vector4` |
+
+When operands differ, the wider numeric type wins:
+
+| Mixed Operands | Result Type |
+|----------------|-------------|
+| `int / float` | `float` |
+| `int / double` | `double` |
+| `float / double` | `double` |
+| `byte / int` | `int` |
+| `short / long` | `long` |
+| `int / decimal` | `decimal` |
+
+**Invalid combinations** (throw `ArgumentException` at construction time):
+- `Quaternion` (no standard division operation).
+- Mixing vector types (e.g., `Vector2 / Vector3`).
+- Mixing vector with numeric types (e.g., `Vector3 / float`).
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves both operands through their respective `IPropertyResolver` instances.
+- Converts each operand to the promoted result type.
+- Performs the division (`left / right`) and returns the result as a `Variant128`.
+- For integer types, division follows C# truncation rules (truncates toward zero).
+- For `Vector2`, `Vector3`, and `Vector4`, division is **component-wise**.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+graph.VariableDefinitions.DefineProperty("damagePerHit",
+    new DivideResolver(
+        new VariableResolver("totalDamage", typeof(int)),
+        new VariableResolver("hitCount", typeof(int))));
+
+graph.VariableDefinitions.DefineProperty("normalizedDirection",
+    new DivideResolver(
+        new VariableResolver("direction", typeof(Vector3)),
+        new VariableResolver("magnitude", typeof(Vector3))));
+```
+
+## Composition
+
+```csharp
+// Average of two attributes: (a + b) / 2
+graph.VariableDefinitions.DefineProperty("averageAttribute",
+    new DivideResolver(
+        new AddResolver(
+            new AttributeResolver("CombatAttributeSet.Strength"),
+            new AttributeResolver("CombatAttributeSet.Dexterity")),
+        new VariantResolver(new Variant128(2), typeof(int))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [MultiplyResolver](multiply-resolver.md)
+- [ModuloResolver](modulo-resolver.md)

--- a/docs/statescript/resolvers/e-resolver.md
+++ b/docs/statescript/resolvers/e-resolver.md
@@ -1,0 +1,42 @@
+# EResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.EResolver`
+> **Output Type:** `float` or `double`
+
+Returns the mathematical constant `e` (Euler's number, the base of the natural logarithm). Defaults to `double` precision. Use this instead of magic numbers to communicate intent clearly.
+
+## Constructor
+
+```csharp
+new EResolver()                // returns double
+new EResolver(typeof(float))   // returns float
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| valueType | `Type?` | The desired output type. Must be `float` or `double`. Defaults to `double`. |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `int`, `decimal`, or any non-floating-point type.
+
+## Behavior
+
+- Returns `Math.E` for `double` or `MathF.E` for `float`.
+- The value is always constant: `2.71828182845904...`.
+
+## Usage
+
+```csharp
+// Natural exponential: e^x
+graph.VariableDefinitions.DefineProperty("naturalExp",
+    new PowResolver(
+        new EResolver(),
+        new VariableResolver("exponent", typeof(double))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [PiResolver](pi-resolver.md)
+- [ExpResolver](exp-resolver.md)
+- [LogResolver](log-resolver.md)

--- a/docs/statescript/resolvers/exp-resolver.md
+++ b/docs/statescript/resolvers/exp-resolver.md
@@ -1,0 +1,56 @@
+# ExpResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.ExpResolver`
+> **Output Type:** `float` or `double`
+
+Computes `e` raised to the specified power (`e^x`). Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new ExpResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the exponent operand. |
+
+## Type Promotion
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `float` | `float` |
+| `double` | `double` |
+| Any integer type | `double` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `decimal` (use `double` instead).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Computes `Math.Exp` (or `MathF.Exp` for `float`) and returns the result as a `Variant128`.
+- `Exp(0) = 1`, `Exp(1) = e ≈ 2.71828`.
+- Negative operands return values approaching zero: `Exp(-1) = 1/e`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Exponential growth: population = initial * Exp(rate * time)
+graph.VariableDefinitions.DefineProperty("population",
+    new MultiplyResolver(
+        new VariableResolver("initialPopulation", typeof(double)),
+        new ExpResolver(
+            new MultiplyResolver(
+                new VariableResolver("growthRate", typeof(double)),
+                new VariableResolver("time", typeof(double))))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [LogResolver](log-resolver.md)
+- [PowResolver](pow-resolver.md)

--- a/docs/statescript/resolvers/floor-resolver.md
+++ b/docs/statescript/resolvers/floor-resolver.md
@@ -1,0 +1,70 @@
+# FloorResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.FloorResolver`
+> **Output Type:** *(same as operand type)*
+
+Computes the largest integer less than or equal to the operand (floor). Only `float`, `double`, and `decimal` types are supported. Integer, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new FloorResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand. |
+
+## Type Promotion
+
+The result type matches the operand type exactly:
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `float` | `float` |
+| `double` | `double` |
+| `decimal` | `decimal` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `int`, `long`, and all other integer types (floor is identity for integers).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Applies `Math.Floor` (or `MathF.Floor` for `float`) and returns the result as a `Variant128`.
+- For positive values, removes the fractional part: `Floor(2.7) = 2.0`.
+- For negative values, rounds away from zero: `Floor(-2.3) = -3.0`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Snap a world position to grid coordinates
+graph.VariableDefinitions.DefineProperty("gridX",
+    new MultiplyResolver(
+        new FloorResolver(
+            new DivideResolver(
+                new VariableResolver("worldX", typeof(double)),
+                new VariableResolver("cellSize", typeof(double)))),
+        new VariableResolver("cellSize", typeof(double))));
+```
+
+## Composition
+
+```csharp
+// Floor damage before applying it
+graph.VariableDefinitions.DefineProperty("finalDamage",
+    new FloorResolver(
+        new MultiplyResolver(
+            new VariableResolver("baseDamage", typeof(double)),
+            new VariableResolver("critMultiplier", typeof(double)))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [CeilResolver](ceil-resolver.md)
+- [RoundResolver](round-resolver.md)
+- [TruncateResolver](truncate-resolver.md)

--- a/docs/statescript/resolvers/lerp-resolver.md
+++ b/docs/statescript/resolvers/lerp-resolver.md
@@ -1,0 +1,98 @@
+# LerpResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.LerpResolver`
+> **Output Type:** `float`, `double`, `Vector2`, `Vector3`, `Vector4`, or `Quaternion`
+
+Computes a linear interpolation between two values. For scalar types, computes `a + (b - a) * t`. For `Vector2`, `Vector3`, `Vector4`, and `Quaternion`, uses the built-in `Lerp` methods from `System.Numerics`. Supports `float` and `double` scalar types. For vector and quaternion types, `a` and `b` must match exactly, and `t` must be `float`. Integer and decimal types are not supported.
+
+## Constructor
+
+```csharp
+new LerpResolver(a, b, t)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| a | `IPropertyResolver` | The resolver for the start value. |
+| b | `IPropertyResolver` | The resolver for the end value. |
+| t | `IPropertyResolver` | The resolver for the interpolation parameter (typically 0 to 1). |
+
+## Type Promotion
+
+### Scalar Types
+
+| Operand Types | Result Type |
+|---------------|-------------|
+| All `float` | `float` |
+| Any `double` | `double` |
+
+### Vector and Quaternion Types
+
+| `a` / `b` Type | `t` Type | Result Type |
+|-----------------|----------|-------------|
+| `Vector2` | `float` | `Vector2` |
+| `Vector3` | `float` | `Vector3` |
+| `Vector4` | `float` | `Vector4` |
+| `Quaternion` | `float` | `Quaternion` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `int`, `long`, `decimal`, and all other integer types.
+- Mismatched `a` and `b` types (e.g., `Vector2` and `Vector3`).
+- Non-`float` `t` for vector/quaternion types.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves all three operands through their respective `IPropertyResolver` instances.
+- For scalar types, computes `a + (b - a) * t` and returns the result as a `Variant128`.
+- For vector types, delegates to `Vector2.Lerp`, `Vector3.Lerp`, or `Vector4.Lerp`.
+- For quaternion types, delegates to `Quaternion.Lerp` (normalized linear interpolation).
+- When `t = 0`, returns `a`. When `t = 1`, returns `b`.
+- Values of `t` outside `[0, 1]` will extrapolate for scalar types. Vector and quaternion built-in Lerp methods may clamp `t`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Smoothly blend between walk and run speed
+graph.VariableDefinitions.DefineProperty("currentSpeed",
+    new LerpResolver(
+        new VariableResolver("walkSpeed", typeof(float)),
+        new VariableResolver("runSpeed", typeof(float)),
+        new VariableResolver("blendFactor", typeof(float))));
+
+// Interpolate between two positions
+graph.VariableDefinitions.DefineProperty("currentPosition",
+    new LerpResolver(
+        new VariableResolver("startPosition", typeof(Vector3)),
+        new VariableResolver("endPosition", typeof(Vector3)),
+        new VariableResolver("progress", typeof(float))));
+
+// Smoothly rotate between two orientations
+graph.VariableDefinitions.DefineProperty("currentRotation",
+    new LerpResolver(
+        new VariableResolver("startRotation", typeof(Quaternion)),
+        new VariableResolver("targetRotation", typeof(Quaternion)),
+        new VariableResolver("rotationProgress", typeof(float))));
+```
+
+## Composition
+
+```csharp
+// Safe lerp with clamped t parameter
+graph.VariableDefinitions.DefineProperty("safeLerp",
+    new LerpResolver(
+        new VariableResolver("startValue", typeof(float)),
+        new VariableResolver("endValue", typeof(float)),
+        new ClampResolver(
+            new VariableResolver("rawT", typeof(float)),
+            new VariantResolver(new Variant128(0.0f), typeof(float)),
+            new VariantResolver(new Variant128(1.0f), typeof(float)))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [ClampResolver](clamp-resolver.md)
+- [AddResolver](add-resolver.md)
+- [MultiplyResolver](multiply-resolver.md)

--- a/docs/statescript/resolvers/lerp-resolver.md
+++ b/docs/statescript/resolvers/lerp-resolver.md
@@ -48,7 +48,7 @@ new LerpResolver(a, b, t)
 - For vector types, delegates to `Vector2.Lerp`, `Vector3.Lerp`, or `Vector4.Lerp`.
 - For quaternion types, delegates to `Quaternion.Lerp` (normalized linear interpolation).
 - When `t = 0`, returns `a`. When `t = 1`, returns `b`.
-- Values of `t` outside `[0, 1]` will extrapolate for scalar types. Vector and quaternion built-in Lerp methods may clamp `t`.
+- Values of `t` outside `[0, 1]` will extrapolate beyond the `[a, b]` range. This applies to both scalar and vector types. `Quaternion.Lerp` also normalizes the result.
 - Type validation happens at construction time (fail-fast), not at runtime.
 
 ## Usage

--- a/docs/statescript/resolvers/log-resolver.md
+++ b/docs/statescript/resolvers/log-resolver.md
@@ -1,0 +1,58 @@
+# LogResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.LogResolver`
+> **Output Type:** `float` or `double`
+
+Computes the natural logarithm (base `e`) of an operand. Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new LogResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand (must be positive). |
+
+## Type Promotion
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `float` | `float` |
+| `double` | `double` |
+| Any integer type | `double` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `decimal` (use `double` instead).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Computes `Math.Log` (or `MathF.Log` for `float`) and returns the result as a `Variant128`.
+- `Log(1) = 0`, `Log(e) = 1`.
+- Negative operands produce `NaN`. Zero produces `-∞`.
+- `Log` and `Exp` are inverses: `Log(Exp(x)) = x`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Logarithmic difficulty scaling
+graph.VariableDefinitions.DefineProperty("difficulty",
+    new AddResolver(
+        new VariableResolver("baseDifficulty", typeof(double)),
+        new MultiplyResolver(
+            new VariableResolver("scaleFactor", typeof(double)),
+            new LogResolver(
+                new VariableResolver("level", typeof(double))))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [ExpResolver](exp-resolver.md)
+- [Log2Resolver](log2-resolver.md)
+- [Log10Resolver](log10-resolver.md)

--- a/docs/statescript/resolvers/log10-resolver.md
+++ b/docs/statescript/resolvers/log10-resolver.md
@@ -1,0 +1,57 @@
+# Log10Resolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.Log10Resolver`
+> **Output Type:** `float` or `double`
+
+Computes the base-10 logarithm of an operand. Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new Log10Resolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand (must be positive). |
+
+## Type Promotion
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `float` | `float` |
+| `double` | `double` |
+| Any integer type | `double` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `decimal` (use `double` instead).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Computes `Math.Log10` (or `MathF.Log10` for `float`) and returns the result as a `Variant128`.
+- `Log10(1) = 0`, `Log10(10) = 1`, `Log10(100) = 2`, `Log10(1000) = 3`.
+- Negative operands produce `NaN`. Zero produces `-∞`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Decibel calculation: dB = 20 * Log10(amplitude / reference)
+graph.VariableDefinitions.DefineProperty("decibels",
+    new MultiplyResolver(
+        new VariantResolver(new Variant128(20.0), typeof(double)),
+        new Log10Resolver(
+            new DivideResolver(
+                new VariableResolver("amplitude", typeof(double)),
+                new VariableResolver("reference", typeof(double))))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [LogResolver](log-resolver.md)
+- [Log2Resolver](log2-resolver.md)
+- [ExpResolver](exp-resolver.md)

--- a/docs/statescript/resolvers/log2-resolver.md
+++ b/docs/statescript/resolvers/log2-resolver.md
@@ -1,0 +1,54 @@
+# Log2Resolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.Log2Resolver`
+> **Output Type:** `float` or `double`
+
+Computes the base-2 logarithm of an operand. Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new Log2Resolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand (must be positive). |
+
+## Type Promotion
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `float` | `float` |
+| `double` | `double` |
+| Any integer type | `double` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `decimal` (use `double` instead).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Computes the base-2 logarithm and returns the result as a `Variant128`.
+- `Log2(1) = 0`, `Log2(2) = 1`, `Log2(8) = 3`, `Log2(1024) = 10`.
+- Negative operands produce `NaN`. Zero produces `-∞`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Calculate bits needed to represent a number of values
+graph.VariableDefinitions.DefineProperty("bitsNeeded",
+    new CeilResolver(
+        new Log2Resolver(
+            new VariableResolver("numValues", typeof(double)))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [LogResolver](log-resolver.md)
+- [Log10Resolver](log10-resolver.md)
+- [ExpResolver](exp-resolver.md)

--- a/docs/statescript/resolvers/max-resolver.md
+++ b/docs/statescript/resolvers/max-resolver.md
@@ -1,0 +1,75 @@
+# MaxResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.MaxResolver`
+> **Output Type:** *(promoted from operand types)*
+
+Returns the larger of two operands. Supports all numeric types in `Variant128`. Vector and quaternion types are not supported. When the two operands have different numeric types, standard numeric promotion rules apply.
+
+## Constructor
+
+```csharp
+new MaxResolver(left, right)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| left | `IPropertyResolver` | The resolver for the left operand. |
+| right | `IPropertyResolver` | The resolver for the right operand. |
+
+## Type Promotion
+
+When both operands have the same type, the result type is determined by promotion rules that mirror C# arithmetic:
+
+| Operand Types | Result Type |
+|---------------|-------------|
+| `byte`, `sbyte`, `short`, `ushort` | `int` |
+| `int` | `int` |
+| `uint` | `long` |
+| `long` | `long` |
+| `ulong` | `double` |
+| `float` | `float` |
+| `double` | `double` |
+| `decimal` | `decimal` |
+
+When operands differ, the wider numeric type wins (e.g., `int` + `double` → `double`).
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves both operands through their respective `IPropertyResolver` instances.
+- Converts each operand to the promoted result type.
+- Returns the larger value as a `Variant128` using `Math.Max`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Ensure a stat never goes below a minimum floor
+graph.VariableDefinitions.DefineProperty("effectiveStat",
+    new MaxResolver(
+        new AddResolver(
+            new VariableResolver("baseStat", typeof(int)),
+            new VariableResolver("modifier", typeof(int))),
+        new VariantResolver(new Variant128(1), typeof(int))));
+```
+
+## Composition
+
+```csharp
+// Non-negative damage after armor reduction
+graph.VariableDefinitions.DefineProperty("effectiveDamage",
+    new MaxResolver(
+        new SubtractResolver(
+            new VariableResolver("rawDamage", typeof(int)),
+            new VariableResolver("armor", typeof(int))),
+        new VariantResolver(new Variant128(0), typeof(int))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [MinResolver](min-resolver.md)
+- [ClampResolver](clamp-resolver.md)

--- a/docs/statescript/resolvers/min-resolver.md
+++ b/docs/statescript/resolvers/min-resolver.md
@@ -1,0 +1,71 @@
+# MinResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.MinResolver`
+> **Output Type:** *(promoted from operand types)*
+
+Returns the smaller of two operands. Supports all numeric types in `Variant128`. Vector and quaternion types are not supported. When the two operands have different numeric types, standard numeric promotion rules apply.
+
+## Constructor
+
+```csharp
+new MinResolver(left, right)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| left | `IPropertyResolver` | The resolver for the left operand. |
+| right | `IPropertyResolver` | The resolver for the right operand. |
+
+## Type Promotion
+
+When both operands have the same type, the result type is determined by promotion rules that mirror C# arithmetic:
+
+| Operand Types | Result Type |
+|---------------|-------------|
+| `byte`, `sbyte`, `short`, `ushort` | `int` |
+| `int` | `int` |
+| `uint` | `long` |
+| `long` | `long` |
+| `ulong` | `double` |
+| `float` | `float` |
+| `double` | `double` |
+| `decimal` | `decimal` |
+
+When operands differ, the wider numeric type wins (e.g., `int` + `double` → `double`).
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves both operands through their respective `IPropertyResolver` instances.
+- Converts each operand to the promoted result type.
+- Returns the smaller value as a `Variant128` using `Math.Min`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Cap a stat to its maximum allowed value
+graph.VariableDefinitions.DefineProperty("effectiveArmor",
+    new MinResolver(
+        new VariableResolver("armor", typeof(int)),
+        new VariableResolver("armorCap", typeof(int))));
+```
+
+## Composition
+
+```csharp
+// Effective damage is at most the target's remaining health
+graph.VariableDefinitions.DefineProperty("actualDamage",
+    new MinResolver(
+        new VariableResolver("rawDamage", typeof(int)),
+        new VariableResolver("targetHealth", typeof(int))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [MaxResolver](max-resolver.md)
+- [ClampResolver](clamp-resolver.md)

--- a/docs/statescript/resolvers/modulo-resolver.md
+++ b/docs/statescript/resolvers/modulo-resolver.md
@@ -52,7 +52,7 @@ When operands differ, the wider numeric type wins:
 - Converts each operand to the promoted result type.
 - Performs the remainder operation (`left % right`) and returns the result as a `Variant128`.
 - For integer types, follows C# truncation-toward-zero semantics (e.g., `-10 % 3 = -1`).
-- For floating-point types, computes the IEEE remainder.
+- For floating-point types, computes the truncated remainder (C# `%` operator), not the IEEE remainder (`Math.IEEERemainder`).
 - Type validation happens at construction time (fail-fast), not at runtime.
 
 ## Usage

--- a/docs/statescript/resolvers/modulo-resolver.md
+++ b/docs/statescript/resolvers/modulo-resolver.md
@@ -1,0 +1,85 @@
+# ModuloResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.ModuloResolver`
+> **Output Type:** *(promoted from operand types)*
+
+Computes the remainder of dividing the left operand by the right operand. Supports all numeric types in `Variant128`. Vector and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new ModuloResolver(left, right)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| left | `IPropertyResolver` | The resolver for the left (dividend) operand. |
+| right | `IPropertyResolver` | The resolver for the right (divisor) operand. |
+
+## Type Promotion
+
+When both operands have the same type, the result type is determined by promotion rules that mirror C# arithmetic:
+
+| Operand Types | Result Type |
+|---------------|-------------|
+| `byte`, `sbyte`, `short`, `ushort` | `int` |
+| `int` | `int` |
+| `uint` | `long` |
+| `long` | `long` |
+| `ulong` | `double` |
+| `float` | `float` |
+| `double` | `double` |
+| `decimal` | `decimal` |
+
+When operands differ, the wider numeric type wins:
+
+| Mixed Operands | Result Type |
+|----------------|-------------|
+| `int % float` | `float` |
+| `int % double` | `double` |
+| `float % double` | `double` |
+| `byte % int` | `int` |
+| `short % long` | `long` |
+| `int % decimal` | `decimal` |
+
+**Invalid combinations** (throw `ArgumentException` at construction time):
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves both operands through their respective `IPropertyResolver` instances.
+- Converts each operand to the promoted result type.
+- Performs the remainder operation (`left % right`) and returns the result as a `Variant128`.
+- For integer types, follows C# truncation-toward-zero semantics (e.g., `-10 % 3 = -1`).
+- For floating-point types, computes the IEEE remainder.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Cycle a counter every N steps
+graph.VariableDefinitions.DefineProperty("cycleIndex",
+    new ModuloResolver(
+        new VariableResolver("tickCount", typeof(int)),
+        new VariantResolver(new Variant128(4), typeof(int))));
+```
+
+## Composition
+
+```csharp
+// Check if a counter is even: (counter % 2) == 0
+graph.VariableDefinitions.DefineProperty("isEvenTick",
+    new ComparisonResolver(
+        new ModuloResolver(
+            new VariableResolver("tickCount", typeof(int)),
+            new VariantResolver(new Variant128(2), typeof(int))),
+        ComparisonOperation.Equal,
+        new VariantResolver(new Variant128(0), typeof(int))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [DivideResolver](divide-resolver.md)
+- [ComparisonResolver](comparison-resolver.md)

--- a/docs/statescript/resolvers/multiply-resolver.md
+++ b/docs/statescript/resolvers/multiply-resolver.md
@@ -1,0 +1,93 @@
+# MultiplyResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.MultiplyResolver`
+> **Output Type:** *(promoted from operand types)*
+
+Multiplies two operands. Supports all numeric types in `Variant128` as well as `Vector2`, `Vector3`, `Vector4` (component-wise multiplication), and `Quaternion` (quaternion multiplication). When the two operands have different numeric types, standard numeric promotion rules apply.
+
+## Constructor
+
+```csharp
+new MultiplyResolver(left, right)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| left | `IPropertyResolver` | The resolver for the left operand. |
+| right | `IPropertyResolver` | The resolver for the right operand. |
+
+## Type Promotion
+
+When both operands have the same type, the result type is determined by promotion rules that mirror C# arithmetic:
+
+| Operand Types | Result Type |
+|---------------|-------------|
+| `byte`, `sbyte`, `short`, `ushort` | `int` |
+| `int` | `int` |
+| `uint` | `long` |
+| `long` | `long` |
+| `ulong` | `double` |
+| `float` | `float` |
+| `double` | `double` |
+| `decimal` | `decimal` |
+| `Vector2` | `Vector2` |
+| `Vector3` | `Vector3` |
+| `Vector4` | `Vector4` |
+| `Quaternion` | `Quaternion` |
+
+When operands differ, the wider numeric type wins:
+
+| Mixed Operands | Result Type |
+|----------------|-------------|
+| `int * float` | `float` |
+| `int * double` | `double` |
+| `float * double` | `double` |
+| `byte * int` | `int` |
+| `short * long` | `long` |
+| `int * decimal` | `decimal` |
+
+**Invalid combinations** (throw `ArgumentException` at construction time):
+- Mixing vector/quaternion types (e.g., `Vector2 * Vector3`).
+- Mixing vector/quaternion with numeric types (e.g., `Vector3 * float`).
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves both operands through their respective `IPropertyResolver` instances.
+- Converts each operand to the promoted result type.
+- Performs the multiplication and returns the result as a `Variant128`.
+- For `Vector2`, `Vector3`, and `Vector4`, multiplication is **component-wise**.
+- For `Quaternion`, multiplication follows standard quaternion multiplication rules (non-commutative).
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+graph.VariableDefinitions.DefineProperty("scaledDamage",
+    new MultiplyResolver(
+        new VariableResolver("baseDamage", typeof(int)),
+        new VariableResolver("multiplier", typeof(int))));
+
+graph.VariableDefinitions.DefineProperty("scaledSize",
+    new MultiplyResolver(
+        new VariableResolver("baseSize", typeof(Vector3)),
+        new VariableResolver("scaleFactors", typeof(Vector3))));
+```
+
+## Composition
+
+```csharp
+// Final damage = (base + bonus) * multiplier
+graph.VariableDefinitions.DefineProperty("finalDamage",
+    new MultiplyResolver(
+        new AddResolver(
+            new VariableResolver("baseDamage", typeof(int)),
+            new VariableResolver("bonusDamage", typeof(int))),
+        new VariableResolver("damageMultiplier", typeof(int))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [DivideResolver](divide-resolver.md)
+- [AddResolver](add-resolver.md)

--- a/docs/statescript/resolvers/negate-resolver.md
+++ b/docs/statescript/resolvers/negate-resolver.md
@@ -1,0 +1,74 @@
+# NegateResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.NegateResolver`
+> **Output Type:** *(same as operand, promoted for sub-int types)*
+
+Negates a single operand (unary minus). Supports all numeric types in `Variant128` as well as `Vector2`, `Vector3`, `Vector4`, and `Quaternion`. Sub-int types (`byte`, `sbyte`, `short`, `ushort`) are promoted to `int`.
+
+## Constructor
+
+```csharp
+new NegateResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand to negate. |
+
+## Type Promotion
+
+The result type matches the operand type, with sub-int types promoted to `int`:
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `byte`, `sbyte`, `short`, `ushort` | `int` |
+| `int` | `int` |
+| `uint` | `long` |
+| `long` | `long` |
+| `ulong` | `double` |
+| `float` | `float` |
+| `double` | `double` |
+| `decimal` | `decimal` |
+| `Vector2` | `Vector2` |
+| `Vector3` | `Vector3` |
+| `Vector4` | `Vector4` |
+| `Quaternion` | `Quaternion` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Applies unary negation (`-value`) and returns the result as a `Variant128`.
+- For vectors and quaternions, negates all components.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+graph.VariableDefinitions.DefineProperty("invertedSpeed",
+    new NegateResolver(
+        new VariableResolver("speed", typeof(float))));
+
+graph.VariableDefinitions.DefineProperty("oppositeDirection",
+    new NegateResolver(
+        new VariableResolver("direction", typeof(Vector3))));
+```
+
+## Composition
+
+```csharp
+// Reverse a velocity and add gravity: -velocity + gravity
+graph.VariableDefinitions.DefineProperty("bouncedVelocity",
+    new AddResolver(
+        new NegateResolver(
+            new VariableResolver("velocity", typeof(Vector3))),
+        new VariableResolver("gravity", typeof(Vector3))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [AbsResolver](abs-resolver.md)
+- [SubtractResolver](subtract-resolver.md)

--- a/docs/statescript/resolvers/pi-resolver.md
+++ b/docs/statescript/resolvers/pi-resolver.md
@@ -1,0 +1,43 @@
+# PiResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.PiResolver`
+> **Output Type:** `float` or `double`
+
+Returns the mathematical constant π (pi). Defaults to `double` precision. Use this instead of magic numbers to communicate intent clearly.
+
+## Constructor
+
+```csharp
+new PiResolver()                // returns double
+new PiResolver(typeof(float))   // returns float
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| valueType | `Type?` | The desired output type. Must be `float` or `double`. Defaults to `double`. |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `int`, `decimal`, or any non-floating-point type.
+
+## Behavior
+
+- Returns `Math.PI` for `double` or `MathF.PI` for `float`.
+- The value is always constant: `3.14159265358979...`.
+
+## Usage
+
+```csharp
+// Circle area: Pi * r^2
+graph.VariableDefinitions.DefineProperty("circleArea",
+    new MultiplyResolver(
+        new PiResolver(),
+        new PowResolver(
+            new VariableResolver("radius", typeof(double)),
+            new VariantResolver(new Variant128(2.0), typeof(double)))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [EResolver](e-resolver.md)
+- [DegToRadResolver](degtorad-resolver.md)

--- a/docs/statescript/resolvers/pow-resolver.md
+++ b/docs/statescript/resolvers/pow-resolver.md
@@ -1,0 +1,70 @@
+# PowResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.PowResolver`
+> **Output Type:** `float` or `double`
+
+Raises a base value to a specified exponent. Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new PowResolver(baseOperand, exponent)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| baseOperand | `IPropertyResolver` | The resolver for the base operand. |
+| exponent | `IPropertyResolver` | The resolver for the exponent operand. |
+
+## Type Promotion
+
+| Operand Types | Result Type |
+|---------------|-------------|
+| Both `float` | `float` |
+| Any `double` | `double` |
+| Any integer type | `double` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `decimal` (use `double` instead).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves both operands through their respective `IPropertyResolver` instances.
+- Computes `Math.Pow(base, exponent)` (or `MathF.Pow` for `float`) and returns the result as a `Variant128`.
+- Any exponent of `0` returns `1`.
+- Any exponent of `1` returns the base value.
+- Fractional exponents compute roots (e.g., `Pow(4, 0.5) = 2`).
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Compute exponential scaling: damage = baseDamage * level^exponent
+graph.VariableDefinitions.DefineProperty("scaledDamage",
+    new MultiplyResolver(
+        new VariableResolver("baseDamage", typeof(double)),
+        new PowResolver(
+            new VariableResolver("level", typeof(double)),
+            new VariantResolver(new Variant128(1.5), typeof(double)))));
+```
+
+## Composition
+
+```csharp
+// Experience curve: xpRequired = baseXP * Pow(level, growthExponent)
+graph.VariableDefinitions.DefineProperty("xpRequired",
+    new FloorResolver(
+        new MultiplyResolver(
+            new VariableResolver("baseXP", typeof(double)),
+            new PowResolver(
+                new VariableResolver("level", typeof(double)),
+                new VariableResolver("growthExponent", typeof(double))))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [SqrtResolver](sqrt-resolver.md)
+- [MultiplyResolver](multiply-resolver.md)

--- a/docs/statescript/resolvers/radtodeg-resolver.md
+++ b/docs/statescript/resolvers/radtodeg-resolver.md
@@ -1,0 +1,54 @@
+# RadToDegResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.RadToDegResolver`
+> **Output Type:** `float` or `double`
+
+Converts an angle from radians to degrees. Computes `radians * (180 / π)`. Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new RadToDegResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand (angle in radians). |
+
+## Type Promotion
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `float` | `float` |
+| `double` | `double` |
+| Any integer type | `double` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `decimal` (use `double` instead).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Multiplies the value by `180 / π` and returns the result as a `Variant128`.
+- `RadToDeg(0) = 0`, `RadToDeg(π/2) = 90`, `RadToDeg(π) = 180`, `RadToDeg(2π) = 360`.
+- `RadToDeg` and `DegToRad` are inverses: `RadToDeg(DegToRad(x)) = x`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Convert ATan2 result to degrees for display
+graph.VariableDefinitions.DefineProperty("aimAngleDegrees",
+    new RadToDegResolver(
+        new ATan2Resolver(
+            new VariableResolver("targetY", typeof(double)),
+            new VariableResolver("targetX", typeof(double)))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [DegToRadResolver](degtorad-resolver.md)
+- [ATan2Resolver](atan2-resolver.md)

--- a/docs/statescript/resolvers/random-resolver.md
+++ b/docs/statescript/resolvers/random-resolver.md
@@ -1,0 +1,72 @@
+# RandomResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.RandomResolver`
+> **Output Type:** `int`, `float`, or `double`
+
+Generates a random value within a range defined by two operands, using a provided `IRandom` implementation. This design allows users to inject any random provider — standard, seeded, blue noise, or network-synchronized — making the resolver deterministic and testable.
+
+## Constructor
+
+```csharp
+new RandomResolver(random, min, max)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| random | `IRandom` | The random provider to use for generating values. |
+| min | `IPropertyResolver` | The resolver for the inclusive minimum bound. |
+| max | `IPropertyResolver` | The resolver for the exclusive maximum bound. |
+
+## Type Promotion
+
+| Operand Types | Result Type |
+|---------------|-------------|
+| Both `int` (or sub-int) | `int` |
+| Both `float` | `float` |
+| Mixed `int`/`float` | `float` |
+| Any `double` | `double` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `long`, `uint`, `ulong` (use `int` or `double` instead).
+- `decimal` (use `double` instead).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves both bound operands through their respective `IPropertyResolver` instances.
+- For `int`: calls `IRandom.NextInt(min, max)` directly, returning a value in `[min, max)`.
+- For `float`: computes `min + NextSingle() * (max - min)`, returning a value in `[min, max)`.
+- For `double`: computes `min + NextDouble() * (max - min)`, returning a value in `[min, max)`.
+- The `IRandom` instance is injected at construction time, not resolved from `GraphContext`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Random damage in a range
+graph.VariableDefinitions.DefineProperty("damage",
+    new AddResolver(
+        new VariableResolver("baseDamage", typeof(float)),
+        new RandomResolver(
+            myRandomProvider,
+            new VariantResolver(new Variant128(0.0f), typeof(float)),
+            new VariableResolver("bonusDamageRange", typeof(float)))));
+```
+
+## Composition
+
+```csharp
+// Random integer for loot table index
+graph.VariableDefinitions.DefineProperty("lootIndex",
+    new RandomResolver(
+        myRandomProvider,
+        new VariantResolver(new Variant128(0), typeof(int)),
+        new VariableResolver("lootTableSize", typeof(int))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [ClampResolver](clamp-resolver.md)
+- [FloorResolver](floor-resolver.md)

--- a/docs/statescript/resolvers/round-resolver.md
+++ b/docs/statescript/resolvers/round-resolver.md
@@ -1,0 +1,67 @@
+# RoundResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.RoundResolver`
+> **Output Type:** *(same as operand type)*
+
+Rounds the operand to the nearest integer using banker's rounding (`MidpointRounding.ToEven`). Only `float`, `double`, and `decimal` types are supported. Integer, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new RoundResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand. |
+
+## Type Promotion
+
+The result type matches the operand type exactly:
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `float` | `float` |
+| `double` | `double` |
+| `decimal` | `decimal` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `int`, `long`, and all other integer types (rounding is identity for integers).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Applies `Math.Round` (or `MathF.Round` for `float`) and returns the result as a `Variant128`.
+- Uses **banker's rounding** (round half to even): `Round(2.5) = 2.0`, `Round(3.5) = 4.0`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Round a computed stat value to the nearest integer
+graph.VariableDefinitions.DefineProperty("displayStat",
+    new RoundResolver(
+        new MultiplyResolver(
+            new VariableResolver("rawStat", typeof(double)),
+            new VariableResolver("modifier", typeof(double)))));
+```
+
+## Composition
+
+```csharp
+// Round after computing an average
+graph.VariableDefinitions.DefineProperty("averageDamage",
+    new RoundResolver(
+        new DivideResolver(
+            new VariableResolver("totalDamage", typeof(double)),
+            new VariableResolver("hitCount", typeof(double)))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [FloorResolver](floor-resolver.md)
+- [CeilResolver](ceil-resolver.md)
+- [TruncateResolver](truncate-resolver.md)

--- a/docs/statescript/resolvers/round-resolver.md
+++ b/docs/statescript/resolvers/round-resolver.md
@@ -3,17 +3,22 @@
 > **Type:** `Gamesmiths.Forge.Statescript.Properties.RoundResolver`
 > **Output Type:** *(same as operand type)*
 
-Rounds the operand to the nearest integer using banker's rounding (`MidpointRounding.ToEven`). Only `float`, `double`, and `decimal` types are supported. Integer, vector, and quaternion types are not supported.
+Rounds the operand to a specified number of fractional digits using a configurable rounding strategy. Only `float`, `double`, and `decimal` types are supported. Integer, vector, and quaternion types are not supported.
 
 ## Constructor
 
 ```csharp
 new RoundResolver(operand)
+new RoundResolver(operand, digits: 2)
+new RoundResolver(operand, mode: MidpointRounding.AwayFromZero)
+new RoundResolver(operand, digits: 2, mode: MidpointRounding.AwayFromZero)
 ```
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| operand | `IPropertyResolver` | The resolver for the operand. |
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| operand | `IPropertyResolver` | *(required)* | The resolver for the operand. |
+| digits | `int` | `0` | Number of fractional digits in the result (0–15). |
+| mode | `MidpointRounding` | `ToEven` | The rounding strategy (banker's rounding by default). |
 
 ## Type Promotion
 
@@ -30,17 +35,30 @@ The result type matches the operand type exactly:
 - `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
 - Unsupported types (`bool`, `char`).
 
+**Invalid digits** (throw `ArgumentOutOfRangeException` at construction time):
+- Values less than `0` or greater than `15`.
+
+## Rounding Modes
+
+| Mode | Behavior | Example (`2.5`) |
+|------|----------|-----------------|
+| `ToEven` (default) | Banker's rounding — rounds to nearest even | `2.0` |
+| `AwayFromZero` | Traditional rounding — always rounds away from zero | `3.0` |
+| `ToZero` | Truncates toward zero | `2.0` |
+| `ToPositiveInfinity` | Rounds toward +∞ (like Ceiling) | `3.0` |
+| `ToNegativeInfinity` | Rounds toward -∞ (like Floor) | `2.0` |
+
 ## Behavior
 
 - Resolves the operand through its `IPropertyResolver` instance.
-- Applies `Math.Round` (or `MathF.Round` for `float`) and returns the result as a `Variant128`.
-- Uses **banker's rounding** (round half to even): `Round(2.5) = 2.0`, `Round(3.5) = 4.0`.
-- Type validation happens at construction time (fail-fast), not at runtime.
+- Applies `Math.Round(value, digits, mode)` and returns the result as a `Variant128`.
+- With default parameters, preserves the original behavior: `Round(2.5) = 2.0` (banker's rounding to integer).
+- Type validation and digits validation happen at construction time (fail-fast), not at runtime.
 
 ## Usage
 
 ```csharp
-// Round a computed stat value to the nearest integer
+// Round a computed stat value to the nearest integer (default behavior)
 graph.VariableDefinitions.DefineProperty("displayStat",
     new RoundResolver(
         new MultiplyResolver(
@@ -51,12 +69,19 @@ graph.VariableDefinitions.DefineProperty("displayStat",
 ## Composition
 
 ```csharp
-// Round after computing an average
-graph.VariableDefinitions.DefineProperty("averageDamage",
+// Display DPS with 1 decimal place
+graph.VariableDefinitions.DefineProperty("dps",
     new RoundResolver(
         new DivideResolver(
             new VariableResolver("totalDamage", typeof(double)),
-            new VariableResolver("hitCount", typeof(double)))));
+            new VariableResolver("elapsed", typeof(double))),
+        digits: 1));
+
+// Traditional rounding for player-facing values
+graph.VariableDefinitions.DefineProperty("displayScore",
+    new RoundResolver(
+        new VariableResolver("rawScore", typeof(double)),
+        mode: MidpointRounding.AwayFromZero));
 ```
 
 ## See Also

--- a/docs/statescript/resolvers/shared-variable-resolver.md
+++ b/docs/statescript/resolvers/shared-variable-resolver.md
@@ -30,6 +30,17 @@ new SharedVariableResolver("comboCounter", typeof(int))
 new SharedVariableResolver("abilityLock", typeof(bool))
 ```
 
+## Composition
+
+```csharp
+// Compare a shared counter against a threshold
+graph.VariableDefinitions.DefineProperty("comboReady",
+    new ComparisonResolver(
+        new SharedVariableResolver("comboCounter", typeof(int)),
+        ComparisonOperation.GreaterThanOrEqual,
+        new VariantResolver(new Variant128(3), typeof(int))));
+```
+
 ## See Also
 
 - [Resolvers Overview](README.md)

--- a/docs/statescript/resolvers/sign-resolver.md
+++ b/docs/statescript/resolvers/sign-resolver.md
@@ -1,0 +1,50 @@
+# SignResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.SignResolver`
+> **Output Type:** `int`
+
+Returns the sign of a numeric operand as `-1`, `0`, or `1`. Supports all signed numeric types. The result is always `int` regardless of the operand type. Unsigned types, vector types, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new SignResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand. |
+
+## Type Promotion
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| Any signed numeric type | `int` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- Unsigned types (`byte`, `ushort`, `uint`, `ulong`).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Returns `-1` for negative values, `0` for zero, and `1` for positive values.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Determine movement direction toward a target
+graph.VariableDefinitions.DefineProperty("moveDirection",
+    new SignResolver(
+        new SubtractResolver(
+            new VariableResolver("targetX", typeof(float)),
+            new VariableResolver("currentX", typeof(float)))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [AbsResolver](abs-resolver.md)
+- [CopySignResolver](copysign-resolver.md)

--- a/docs/statescript/resolvers/sin-resolver.md
+++ b/docs/statescript/resolvers/sin-resolver.md
@@ -1,0 +1,56 @@
+# SinResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.SinResolver`
+> **Output Type:** `float` or `double`
+
+Computes the sine of an operand (in radians). Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new SinResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand (angle in radians). |
+
+## Type Promotion
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `float` | `float` |
+| `double` | `double` |
+| Any integer type | `double` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `decimal` (use `double` instead).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Computes `Math.Sin` (or `MathF.Sin` for `float`) and returns the result as a `Variant128`.
+- `Sin(0) = 0`, `Sin(π/2) = 1`, `Sin(π) = 0`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Oscillating value for bobbing animation
+graph.VariableDefinitions.DefineProperty("bobOffset",
+    new MultiplyResolver(
+        new VariableResolver("amplitude", typeof(float)),
+        new SinResolver(
+            new MultiplyResolver(
+                new VariableResolver("frequency", typeof(float)),
+                new VariableResolver("time", typeof(float))))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [CosResolver](cos-resolver.md)
+- [TanResolver](tan-resolver.md)
+- [ASinResolver](asin-resolver.md)

--- a/docs/statescript/resolvers/sinh-resolver.md
+++ b/docs/statescript/resolvers/sinh-resolver.md
@@ -1,0 +1,43 @@
+# SinHResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.SinHResolver`
+> **Output Type:** `float` or `double`
+
+Computes the hyperbolic sine of an operand. Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new SinHResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand. |
+
+## Type Promotion
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `float` | `float` |
+| `double` | `double` |
+| Any integer type | `double` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `decimal` (use `double` instead).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Computes `Math.Sinh` (or `MathF.Sinh` for `float`) and returns the result as a `Variant128`.
+- `SinH(0) = 0`. SinH is an odd function: `SinH(-x) = -SinH(x)`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [CosHResolver](cosh-resolver.md)
+- [TanHResolver](tanh-resolver.md)
+- [ASinHResolver](asinh-resolver.md)

--- a/docs/statescript/resolvers/sqrt-resolver.md
+++ b/docs/statescript/resolvers/sqrt-resolver.md
@@ -1,0 +1,76 @@
+# SqrtResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.SqrtResolver`
+> **Output Type:** `float` or `double`
+
+Computes the square root of a single operand. Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new SqrtResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand. |
+
+## Type Promotion
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `float` | `float` |
+| `double` | `double` |
+| Any integer type | `double` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `decimal` (use `double` instead).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Computes `Math.Sqrt` (or `MathF.Sqrt` for `float`) and returns the result as a `Variant128`.
+- `Sqrt(0)` returns `0`. `Sqrt(1)` returns `1`.
+- Negative operands produce `NaN` (consistent with `Math.Sqrt` behavior).
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Compute distance between two 2D points
+graph.VariableDefinitions.DefineProperty("distance",
+    new SqrtResolver(
+        new AddResolver(
+            new PowResolver(
+                new SubtractResolver(
+                    new VariableResolver("x2", typeof(double)),
+                    new VariableResolver("x1", typeof(double))),
+                new VariantResolver(new Variant128(2.0), typeof(double))),
+            new PowResolver(
+                new SubtractResolver(
+                    new VariableResolver("y2", typeof(double)),
+                    new VariableResolver("y1", typeof(double))),
+                new VariantResolver(new Variant128(2.0), typeof(double))))));
+```
+
+## Composition
+
+```csharp
+// Level-based stat scaling: stat = baseStat + Floor(Sqrt(level) * growthRate)
+graph.VariableDefinitions.DefineProperty("scaledStat",
+    new AddResolver(
+        new VariableResolver("baseStat", typeof(double)),
+        new FloorResolver(
+            new MultiplyResolver(
+                new SqrtResolver(
+                    new VariableResolver("level", typeof(double))),
+                new VariableResolver("growthRate", typeof(double))))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [PowResolver](pow-resolver.md)
+- [FloorResolver](floor-resolver.md)

--- a/docs/statescript/resolvers/subtract-resolver.md
+++ b/docs/statescript/resolvers/subtract-resolver.md
@@ -1,0 +1,92 @@
+# SubtractResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.SubtractResolver`
+> **Output Type:** *(promoted from operand types)*
+
+Subtracts the right operand from the left operand. Supports all numeric types in `Variant128` as well as `Vector2`, `Vector3`, `Vector4`, and `Quaternion`. When the two operands have different numeric types, standard numeric promotion rules apply.
+
+## Constructor
+
+```csharp
+new SubtractResolver(left, right)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| left | `IPropertyResolver` | The resolver for the left (minuend) operand. |
+| right | `IPropertyResolver` | The resolver for the right (subtrahend) operand. |
+
+## Type Promotion
+
+When both operands have the same type, the result type is determined by promotion rules that mirror C# arithmetic:
+
+| Operand Types | Result Type |
+|---------------|-------------|
+| `byte`, `sbyte`, `short`, `ushort` | `int` |
+| `int` | `int` |
+| `uint` | `long` |
+| `long` | `long` |
+| `ulong` | `double` |
+| `float` | `float` |
+| `double` | `double` |
+| `decimal` | `decimal` |
+| `Vector2` | `Vector2` |
+| `Vector3` | `Vector3` |
+| `Vector4` | `Vector4` |
+| `Quaternion` | `Quaternion` |
+
+When operands differ, the wider numeric type wins:
+
+| Mixed Operands | Result Type |
+|----------------|-------------|
+| `int - float` | `float` |
+| `int - double` | `double` |
+| `float - double` | `double` |
+| `byte - int` | `int` |
+| `short - long` | `long` |
+| `int - decimal` | `decimal` |
+
+**Invalid combinations** (throw `ArgumentException` at construction time):
+- Mixing vector/quaternion types (e.g., `Vector2 - Vector3`).
+- Mixing vector/quaternion with numeric types (e.g., `Vector3 - float`).
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves both operands through their respective `IPropertyResolver` instances.
+- Converts each operand to the promoted result type.
+- Performs the subtraction (`left - right`) and returns the result as a `Variant128`.
+- For vectors, subtraction is component-wise.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+graph.VariableDefinitions.DefineProperty("remainingHealth",
+    new SubtractResolver(
+        new VariableResolver("maxHealth", typeof(int)),
+        new VariableResolver("damageTaken", typeof(int))));
+
+graph.VariableDefinitions.DefineProperty("displacement",
+    new SubtractResolver(
+        new VariableResolver("currentPosition", typeof(Vector3)),
+        new VariableResolver("startPosition", typeof(Vector3))));
+```
+
+## Composition
+
+```csharp
+// Compute remaining health as a percentage: (max - current) / max
+graph.VariableDefinitions.DefineProperty("healthLostFraction",
+    new DivideResolver(
+        new SubtractResolver(
+            new VariableResolver("maxHealth", typeof(float)),
+            new VariableResolver("currentHealth", typeof(float))),
+        new VariableResolver("maxHealth", typeof(float))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [AddResolver](add-resolver.md)
+- [NegateResolver](negate-resolver.md)

--- a/docs/statescript/resolvers/tan-resolver.md
+++ b/docs/statescript/resolvers/tan-resolver.md
@@ -1,0 +1,43 @@
+# TanResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.TanResolver`
+> **Output Type:** `float` or `double`
+
+Computes the tangent of an operand (in radians). Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new TanResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand (angle in radians). |
+
+## Type Promotion
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `float` | `float` |
+| `double` | `double` |
+| Any integer type | `double` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `decimal` (use `double` instead).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Computes `Math.Tan` (or `MathF.Tan` for `float`) and returns the result as a `Variant128`.
+- `Tan(0) = 0`, `Tan(π/4) = 1`.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [SinResolver](sin-resolver.md)
+- [CosResolver](cos-resolver.md)
+- [ATanResolver](atan-resolver.md)

--- a/docs/statescript/resolvers/tanh-resolver.md
+++ b/docs/statescript/resolvers/tanh-resolver.md
@@ -1,0 +1,59 @@
+# TanHResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.TanHResolver`
+> **Output Type:** `float` or `double`
+
+Computes the hyperbolic tangent of an operand. Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new TanHResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand. |
+
+## Type Promotion
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `float` | `float` |
+| `double` | `double` |
+| Any integer type | `double` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `decimal` (use `double` instead).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Computes `Math.Tanh` (or `MathF.Tanh` for `float`) and returns the result as a `Variant128`.
+- `TanH(0) = 0`. Output is bounded to `(-1, 1)`.
+- TanH is an odd function: `TanH(-x) = -TanH(x)`.
+- Large positive values approach `1`, large negative values approach `-1`.
+- Useful for smooth activation functions and easing curves.
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+## Usage
+
+```csharp
+// Smooth step mapping: maps (-∞,+∞) to (0, 1)
+graph.VariableDefinitions.DefineProperty("smoothValue",
+    new DivideResolver(
+        new AddResolver(
+            new TanHResolver(
+                new VariableResolver("rawInput", typeof(double))),
+            new VariantResolver(new Variant128(1.0), typeof(double))),
+        new VariantResolver(new Variant128(2.0), typeof(double))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [SinHResolver](sinh-resolver.md)
+- [CosHResolver](cosh-resolver.md)
+- [ATanHResolver](atanh-resolver.md)

--- a/docs/statescript/resolvers/truncate-resolver.md
+++ b/docs/statescript/resolvers/truncate-resolver.md
@@ -1,0 +1,77 @@
+# TruncateResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.TruncateResolver`
+> **Output Type:** *(same as operand type)*
+
+Removes the fractional part of the operand, always rounding toward zero. Only `float`, `double`, and `decimal` types are supported. Integer, vector, and quaternion types are not supported.
+
+## Constructor
+
+```csharp
+new TruncateResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the operand. |
+
+## Type Promotion
+
+The result type matches the operand type exactly:
+
+| Operand Type | Result Type |
+|--------------|-------------|
+| `float` | `float` |
+| `double` | `double` |
+| `decimal` | `decimal` |
+
+**Invalid types** (throw `ArgumentException` at construction time):
+- `int`, `long`, and all other integer types (truncation is identity for integers).
+- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Unsupported types (`bool`, `char`).
+
+## Behavior
+
+- Resolves the operand through its `IPropertyResolver` instance.
+- Applies `Math.Truncate` (or `MathF.Truncate` for `float`) and returns the result as a `Variant128`.
+- Always rounds **toward zero**: `Truncate(2.7) = 2.0`, `Truncate(-2.7) = -2.0`.
+- This differs from `Floor` (which rounds toward negative infinity) and `Ceil` (which rounds toward positive infinity).
+- Type validation happens at construction time (fail-fast), not at runtime.
+
+### Comparison of Rounding Resolvers
+
+| Value | Floor | Ceil | Round | Truncate |
+|-------|-------|------|-------|----------|
+| 2.7 | 2.0 | 3.0 | 3.0 | 2.0 |
+| 2.3 | 2.0 | 3.0 | 2.0 | 2.0 |
+| -2.7 | -3.0 | -2.0 | -3.0 | -2.0 |
+| -2.3 | -3.0 | -2.0 | -2.0 | -2.0 |
+
+## Usage
+
+```csharp
+// Convert a float coordinate to a grid index (always toward zero)
+graph.VariableDefinitions.DefineProperty("gridIndex",
+    new TruncateResolver(
+        new DivideResolver(
+            new VariableResolver("position", typeof(double)),
+            new VariableResolver("cellSize", typeof(double)))));
+```
+
+## Composition
+
+```csharp
+// Truncate integer division result for consistent behavior with negative numbers
+graph.VariableDefinitions.DefineProperty("quotient",
+    new TruncateResolver(
+        new DivideResolver(
+            new VariableResolver("dividend", typeof(double)),
+            new VariableResolver("divisor", typeof(double)))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [FloorResolver](floor-resolver.md)
+- [CeilResolver](ceil-resolver.md)
+- [RoundResolver](round-resolver.md)

--- a/docs/statescript/resolvers/variable-resolver.md
+++ b/docs/statescript/resolvers/variable-resolver.md
@@ -30,6 +30,16 @@ new VariableResolver("counter", typeof(int))
 new VariableResolver("speed", typeof(double))
 ```
 
+## Composition
+
+```csharp
+// Use a graph variable as an operand in arithmetic
+graph.VariableDefinitions.DefineProperty("boostedSpeed",
+    new MultiplyResolver(
+        new VariableResolver("baseSpeed", typeof(float)),
+        new VariantResolver(new Variant128(1.5f), typeof(float))));
+```
+
 ## See Also
 
 - [Resolvers Overview](README.md)

--- a/docs/statescript/resolvers/variant-resolver.md
+++ b/docs/statescript/resolvers/variant-resolver.md
@@ -29,6 +29,17 @@ new VariantResolver(new Variant128(3.14f), typeof(float))   // Constant 3.14
 new VariantResolver(new Variant128(true), typeof(bool))     // Constant true
 ```
 
+## Composition
+
+```csharp
+// Use as a constant operand in a comparison
+graph.VariableDefinitions.DefineProperty("isOverThreshold",
+    new ComparisonResolver(
+        new AttributeResolver("CombatAttributeSet.Health"),
+        ComparisonOperation.GreaterThan,
+        new VariantResolver(new Variant128(50), typeof(int))));
+```
+
 ## See Also
 
 - [Resolvers Overview](README.md)

--- a/docs/statescript/templates/resolver-template.md
+++ b/docs/statescript/templates/resolver-template.md
@@ -31,7 +31,7 @@ new {ClassName}({parameters})
 
 ## Composition
 
-{Show how this resolver composes with other resolvers, if applicable.}
+{Show how this resolver composes with other resolvers. For resolvers that accept `IPropertyResolver` operands, show nesting. For leaf resolvers (constants, variable reads), show them being used as operands in math or comparison resolvers.}
 
 ```csharp
 // {Example showing composition}


### PR DESCRIPTION
This PR adds several Math resolvers which should be enough to cover well above 90% of the use cases.

## Math Resolvers

| Resolver | Output Type | Description |
|----------|-------------|-------------|
| AbsResolver | *(promoted)* | Computes the absolute value of a signed numeric value. |
| ACosHResolver | `float`/`double` | Computes the inverse hyperbolic cosine. |
| ACosResolver | `float`/`double` | Computes the arc cosine (inverse cosine), returning angle in radians. |
| AddResolver | *(promoted)* | Adds two numeric or vector values. |
| ASinHResolver | `float`/`double` | Computes the inverse hyperbolic sine. |
| ASinResolver | `float`/`double` | Computes the arc sine (inverse sine), returning angle in radians. |
| ATan2Resolver | `float`/`double` | Computes the angle from two coordinates using `ATan2(y, x)`. |
| ATanHResolver | `float`/`double` | Computes the inverse hyperbolic tangent. |
| ATanResolver | `float`/`double` | Computes the arc tangent (inverse tangent), returning angle in radians. |
| CbrtResolver | `float`/`double` | Computes the cube root. |
| CeilResolver | *(same)* | Rounds up to the smallest integer greater than or equal to the operand. |
| ClampResolver | *(promoted)* | Clamps a numeric value between a minimum and maximum bound. |
| CopySignResolver | `float`/`double` | Returns a value with the magnitude of one operand and the sign of another. |
| CosHResolver | `float`/`double` | Computes the hyperbolic cosine. |
| CosResolver | `float`/`double` | Computes the cosine of an angle in radians. |
| DegToRadResolver | `float`/`double` | Converts degrees to radians. |
| DivideResolver | *(promoted)* | Divides two numeric or vector values. |
| EResolver | `float`/`double` | Returns the mathematical constant `e` (Euler's number). |
| ExpResolver | `float`/`double` | Computes `e` raised to a specified power (`e^x`). |
| FloorResolver | *(same)* | Rounds down to the largest integer less than or equal to the operand. |
| LerpResolver | `float`/`double`/vector/quaternion | Linearly interpolates between two values (scalar, vector, or quaternion). |
| Log10Resolver | `float`/`double` | Computes the base-10 logarithm. |
| Log2Resolver | `float`/`double` | Computes the base-2 logarithm. |
| LogResolver | `float`/`double` | Computes the natural logarithm (base `e`). |
| MaxResolver | *(promoted)* | Returns the larger of two numeric values. |
| MinResolver | *(promoted)* | Returns the smaller of two numeric values. |
| ModuloResolver | *(promoted)* | Computes the remainder of dividing two numeric values. |
| MultiplyResolver | *(promoted)* | Multiplies two numeric or vector values. |
| NegateResolver | *(promoted)* | Negates a numeric or vector value. |
| PiResolver | `float`/`double` | Returns the mathematical constant π (pi). |
| PowResolver | `float`/`double` | Raises a value to a specified power. |
| RadToDegResolver | `float`/`double` | Converts radians to degrees. |
| RandomResolver | `int`/`float`/`double` | Generates a random value in a range using an `IRandom` provider. |
| RoundResolver | *(same)* | Rounds to a specified number of digits with configurable rounding mode. |
| SignResolver | `int` | Returns -1, 0, or 1 indicating the sign of a numeric value. |
| SinHResolver | `float`/`double` | Computes the hyperbolic sine. |
| SinResolver | `float`/`double` | Computes the sine of an angle in radians. |
| SqrtResolver | `float`/`double` | Computes the square root of a numeric value. |
| SubtractResolver | *(promoted)* | Subtracts two numeric or vector values. |
| TanHResolver | `float`/`double` | Computes the hyperbolic tangent. |
| TanResolver | `float`/`double` | Computes the tangent of an angle in radians. |
| TruncateResolver | *(same)* | Removes the fractional part, rounding toward zero. |