### PR TITLE
Added boolean operation resolvers.

### DIFF
--- a/Forge.Tests/Statescript/Nodes/Condition/ExpressionNodeTests.cs
+++ b/Forge.Tests/Statescript/Nodes/Condition/ExpressionNodeTests.cs
@@ -282,6 +282,49 @@ public class ExpressionNodeTests(TagsAndCuesFixture tagsAndCuesFixture) : IClass
 
 	[Fact]
 	[Trait("Graph", "Expression")]
+	public void Expression_condition_node_supports_composed_boolean_resolvers()
+	{
+		var graph = new Graph();
+		graph.VariableDefinitions.DefineVariable("leftTriggerPressed", true);
+		graph.VariableDefinitions.DefineVariable("rightTriggerPressed", false);
+		graph.VariableDefinitions.DefineVariable("isDisabled", false);
+
+		graph.VariableDefinitions.DefineProperty(
+			"shouldActivate",
+			new AndResolver(
+				new XorResolver(
+					new VariableResolver("leftTriggerPressed", typeof(bool)),
+					new VariableResolver("rightTriggerPressed", typeof(bool))),
+				new NotResolver(
+					new VariableResolver("isDisabled", typeof(bool)))));
+
+		ExpressionNode condition = CreateExpressionNode("shouldActivate");
+		var trueAction = new TrackingActionNode();
+		var falseAction = new TrackingActionNode();
+
+		graph.AddNode(condition);
+		graph.AddNode(trueAction);
+		graph.AddNode(falseAction);
+
+		graph.AddConnection(new Connection(
+			graph.EntryNode.OutputPorts[EntryNode.OutputPort],
+			condition.InputPorts[ConditionNode.InputPort]));
+		graph.AddConnection(new Connection(
+			condition.OutputPorts[ConditionNode.TruePort],
+			trueAction.InputPorts[ActionNode.InputPort]));
+		graph.AddConnection(new Connection(
+			condition.OutputPorts[ConditionNode.FalsePort],
+			falseAction.InputPorts[ActionNode.InputPort]));
+
+		var processor = new GraphProcessor(graph);
+		processor.StartGraph();
+
+		trueAction.ExecutionCount.Should().Be(1);
+		falseAction.ExecutionCount.Should().Be(0);
+	}
+
+	[Fact]
+	[Trait("Graph", "Expression")]
 	public void Comparison_resolver_works_with_int_operands()
 	{
 		var graph = new Graph();

--- a/Forge.Tests/Statescript/Resolvers/AndResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/AndResolverTests.cs
@@ -1,0 +1,124 @@
+// Copyright © Gamesmiths Guild.
+
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class AndResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "And")]
+	public void And_resolver_value_type_is_bool()
+	{
+		var resolver = new AndResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)),
+			new VariantResolver(new Variant128(false), typeof(bool)));
+
+		resolver.ValueType.Should().Be(typeof(bool));
+	}
+
+	[Fact]
+	[Trait("Resolver", "And")]
+	public void And_resolver_returns_true_when_both_operands_are_true()
+	{
+		var resolver = new AndResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)),
+			new VariantResolver(new Variant128(true), typeof(bool)));
+
+		resolver.Resolve(new GraphContext()).AsBool().Should().BeTrue();
+	}
+
+	[Fact]
+	[Trait("Resolver", "And")]
+	public void And_resolver_returns_false_when_left_operand_is_false()
+	{
+		var resolver = new AndResolver(
+			new VariantResolver(new Variant128(false), typeof(bool)),
+			new VariantResolver(new Variant128(true), typeof(bool)));
+
+		resolver.Resolve(new GraphContext()).AsBool().Should().BeFalse();
+	}
+
+	[Fact]
+	[Trait("Resolver", "And")]
+	public void And_resolver_returns_false_when_right_operand_is_false()
+	{
+		var resolver = new AndResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)),
+			new VariantResolver(new Variant128(false), typeof(bool)));
+
+		resolver.Resolve(new GraphContext()).AsBool().Should().BeFalse();
+	}
+
+	[Fact]
+	[Trait("Resolver", "And")]
+	public void And_resolver_supports_nested_boolean_resolvers()
+	{
+		var resolver = new AndResolver(
+			new ComparisonResolver(
+				new VariantResolver(new Variant128(10), typeof(int)),
+				ComparisonOperation.GreaterThan,
+				new VariantResolver(new Variant128(5), typeof(int))),
+			new NotResolver(
+				new ComparisonResolver(
+					new VariantResolver(new Variant128(3), typeof(int)),
+					ComparisonOperation.Equal,
+					new VariantResolver(new Variant128(4), typeof(int)))));
+
+		resolver.Resolve(new GraphContext()).AsBool().Should().BeTrue();
+	}
+
+	[Fact]
+	[Trait("Resolver", "And")]
+	public void And_resolver_resolves_both_operands()
+	{
+		var left = new CountingBoolResolver(false);
+		var right = new CountingBoolResolver(true);
+		var resolver = new AndResolver(left, right);
+
+		resolver.Resolve(new GraphContext()).AsBool().Should().BeFalse();
+		left.ResolveCount.Should().Be(1);
+		right.ResolveCount.Should().Be(1);
+	}
+
+	[Fact]
+	[Trait("Resolver", "And")]
+	public void And_resolver_throws_for_non_bool_left_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new AndResolver(
+			new VariantResolver(new Variant128(1), typeof(int)),
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "And")]
+	public void And_resolver_throws_for_non_bool_right_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new AndResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)),
+			new VariantResolver(new Variant128(1), typeof(int)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	private sealed class CountingBoolResolver(bool value) : IPropertyResolver
+	{
+		public int ResolveCount { get; private set; }
+
+		public Type ValueType => typeof(bool);
+
+		public Variant128 Resolve(GraphContext graphContext)
+		{
+			ResolveCount++;
+			return new Variant128(value);
+		}
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/NotResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/NotResolverTests.cs
@@ -1,0 +1,76 @@
+// Copyright © Gamesmiths Guild.
+
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class NotResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Not")]
+	public void Not_resolver_value_type_is_bool()
+	{
+		var resolver = new NotResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+
+		resolver.ValueType.Should().Be(typeof(bool));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Not")]
+	public void Not_resolver_returns_true_when_operand_is_false()
+	{
+		var resolver = new NotResolver(
+			new VariantResolver(new Variant128(false), typeof(bool)));
+
+		resolver.Resolve(new GraphContext()).AsBool().Should().BeTrue();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Not")]
+	public void Not_resolver_returns_false_when_operand_is_true()
+	{
+		var resolver = new NotResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)));
+
+		resolver.Resolve(new GraphContext()).AsBool().Should().BeFalse();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Not")]
+	public void Not_resolver_supports_nested_boolean_resolvers()
+	{
+		var resolver = new NotResolver(
+			new ComparisonResolver(
+				new VariantResolver(new Variant128(3), typeof(int)),
+				ComparisonOperation.GreaterThan,
+				new VariantResolver(new Variant128(10), typeof(int))));
+
+		resolver.Resolve(new GraphContext()).AsBool().Should().BeTrue();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Not")]
+	public void Not_resolver_double_negation_returns_original_value()
+	{
+		var resolver = new NotResolver(
+			new NotResolver(
+				new VariantResolver(new Variant128(true), typeof(bool))));
+
+		resolver.Resolve(new GraphContext()).AsBool().Should().BeTrue();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Not")]
+	public void Not_resolver_throws_for_non_bool_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new NotResolver(
+			new VariantResolver(new Variant128(1), typeof(int)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/OrResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/OrResolverTests.cs
@@ -1,0 +1,123 @@
+// Copyright © Gamesmiths Guild.
+
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class OrResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Or")]
+	public void Or_resolver_value_type_is_bool()
+	{
+		var resolver = new OrResolver(
+			new VariantResolver(new Variant128(false), typeof(bool)),
+			new VariantResolver(new Variant128(true), typeof(bool)));
+
+		resolver.ValueType.Should().Be(typeof(bool));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Or")]
+	public void Or_resolver_returns_false_when_both_operands_are_false()
+	{
+		var resolver = new OrResolver(
+			new VariantResolver(new Variant128(false), typeof(bool)),
+			new VariantResolver(new Variant128(false), typeof(bool)));
+
+		resolver.Resolve(new GraphContext()).AsBool().Should().BeFalse();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Or")]
+	public void Or_resolver_returns_true_when_left_operand_is_true()
+	{
+		var resolver = new OrResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)),
+			new VariantResolver(new Variant128(false), typeof(bool)));
+
+		resolver.Resolve(new GraphContext()).AsBool().Should().BeTrue();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Or")]
+	public void Or_resolver_returns_true_when_right_operand_is_true()
+	{
+		var resolver = new OrResolver(
+			new VariantResolver(new Variant128(false), typeof(bool)),
+			new VariantResolver(new Variant128(true), typeof(bool)));
+
+		resolver.Resolve(new GraphContext()).AsBool().Should().BeTrue();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Or")]
+	public void Or_resolver_supports_nested_boolean_resolvers()
+	{
+		var resolver = new OrResolver(
+			new ComparisonResolver(
+				new VariantResolver(new Variant128(2), typeof(int)),
+				ComparisonOperation.GreaterThan,
+				new VariantResolver(new Variant128(5), typeof(int))),
+			new ComparisonResolver(
+				new VariantResolver(new Variant128(7), typeof(int)),
+				ComparisonOperation.GreaterThan,
+				new VariantResolver(new Variant128(5), typeof(int))));
+
+		resolver.Resolve(new GraphContext()).AsBool().Should().BeTrue();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Or")]
+	public void Or_resolver_resolves_both_operands()
+	{
+		var left = new CountingBoolResolver(true);
+		var right = new CountingBoolResolver(false);
+		var resolver = new OrResolver(left, right);
+
+		resolver.Resolve(new GraphContext()).AsBool().Should().BeTrue();
+		left.ResolveCount.Should().Be(1);
+		right.ResolveCount.Should().Be(1);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Or")]
+	public void Or_resolver_throws_for_non_bool_left_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new OrResolver(
+			new VariantResolver(new Variant128(1), typeof(int)),
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Or")]
+	public void Or_resolver_throws_for_non_bool_right_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new OrResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)),
+			new VariantResolver(new Variant128(1), typeof(int)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	private sealed class CountingBoolResolver(bool value) : IPropertyResolver
+	{
+		public int ResolveCount { get; private set; }
+
+		public Type ValueType => typeof(bool);
+
+		public Variant128 Resolve(GraphContext graphContext)
+		{
+			ResolveCount++;
+			return new Variant128(value);
+		}
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/XorResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/XorResolverTests.cs
@@ -1,0 +1,134 @@
+// Copyright © Gamesmiths Guild.
+
+using FluentAssertions;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class XorResolverTests
+{
+	[Fact]
+	[Trait("Resolver", "Xor")]
+	public void Xor_resolver_value_type_is_bool()
+	{
+		var resolver = new XorResolver(
+			new VariantResolver(new Variant128(false), typeof(bool)),
+			new VariantResolver(new Variant128(true), typeof(bool)));
+
+		resolver.ValueType.Should().Be(typeof(bool));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Xor")]
+	public void Xor_resolver_returns_false_when_both_operands_are_false()
+	{
+		var resolver = new XorResolver(
+			new VariantResolver(new Variant128(false), typeof(bool)),
+			new VariantResolver(new Variant128(false), typeof(bool)));
+
+		resolver.Resolve(new GraphContext()).AsBool().Should().BeFalse();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Xor")]
+	public void Xor_resolver_returns_true_when_only_left_operand_is_true()
+	{
+		var resolver = new XorResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)),
+			new VariantResolver(new Variant128(false), typeof(bool)));
+
+		resolver.Resolve(new GraphContext()).AsBool().Should().BeTrue();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Xor")]
+	public void Xor_resolver_returns_true_when_only_right_operand_is_true()
+	{
+		var resolver = new XorResolver(
+			new VariantResolver(new Variant128(false), typeof(bool)),
+			new VariantResolver(new Variant128(true), typeof(bool)));
+
+		resolver.Resolve(new GraphContext()).AsBool().Should().BeTrue();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Xor")]
+	public void Xor_resolver_returns_false_when_both_operands_are_true()
+	{
+		var resolver = new XorResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)),
+			new VariantResolver(new Variant128(true), typeof(bool)));
+
+		resolver.Resolve(new GraphContext()).AsBool().Should().BeFalse();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Xor")]
+	public void Xor_resolver_supports_nested_boolean_resolvers()
+	{
+		var resolver = new XorResolver(
+			new ComparisonResolver(
+				new VariantResolver(new Variant128(10), typeof(int)),
+				ComparisonOperation.GreaterThan,
+				new VariantResolver(new Variant128(5), typeof(int))),
+			new ComparisonResolver(
+				new VariantResolver(new Variant128(2), typeof(int)),
+				ComparisonOperation.GreaterThan,
+				new VariantResolver(new Variant128(5), typeof(int))));
+
+		resolver.Resolve(new GraphContext()).AsBool().Should().BeTrue();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Xor")]
+	public void Xor_resolver_resolves_both_operands()
+	{
+		var left = new CountingBoolResolver(true);
+		var right = new CountingBoolResolver(false);
+		var resolver = new XorResolver(left, right);
+
+		resolver.Resolve(new GraphContext()).AsBool().Should().BeTrue();
+		left.ResolveCount.Should().Be(1);
+		right.ResolveCount.Should().Be(1);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Xor")]
+	public void Xor_resolver_throws_for_non_bool_left_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new XorResolver(
+			new VariantResolver(new Variant128(1), typeof(int)),
+			new VariantResolver(new Variant128(true), typeof(bool)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	[Trait("Resolver", "Xor")]
+	public void Xor_resolver_throws_for_non_bool_right_operand()
+	{
+#pragma warning disable CA1806
+		Action act = () => new XorResolver(
+			new VariantResolver(new Variant128(true), typeof(bool)),
+			new VariantResolver(new Variant128(1), typeof(int)));
+#pragma warning restore CA1806
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	private sealed class CountingBoolResolver(bool value) : IPropertyResolver
+	{
+		public int ResolveCount { get; private set; }
+
+		public Type ValueType => typeof(bool);
+
+		public Variant128 Resolve(GraphContext graphContext)
+		{
+			ResolveCount++;
+			return new Variant128(value);
+		}
+	}
+}

--- a/Forge/Statescript/Properties/AndResolver.cs
+++ b/Forge/Statescript/Properties/AndResolver.cs
@@ -1,0 +1,33 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the logical conjunction of two nested <see cref="IPropertyResolver"/> operands. Both operands must
+/// resolve to <see cref="bool"/>.
+/// </summary>
+/// <remarks>
+/// Both operands are resolved on every call before applying the boolean operator.
+/// </remarks>
+/// <param name="left">The resolver for the left operand.</param>
+/// <param name="right">The resolver for the right operand.</param>
+public class AndResolver(IPropertyResolver left, IPropertyResolver right) : IPropertyResolver
+{
+	private readonly IPropertyResolver _left =
+		BooleanTypeUtils.ValidateBoolOperand(nameof(AndResolver), nameof(left), left);
+
+	private readonly IPropertyResolver _right =
+		BooleanTypeUtils.ValidateBoolOperand(nameof(AndResolver), nameof(right), right);
+
+	/// <inheritdoc/>
+	public Type ValueType => typeof(bool);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		var leftValue = _left.Resolve(graphContext).AsBool();
+		var rightValue = _right.Resolve(graphContext).AsBool();
+
+		return new Variant128(leftValue && rightValue);
+	}
+}

--- a/Forge/Statescript/Properties/BooleanTypeUtils.cs
+++ b/Forge/Statescript/Properties/BooleanTypeUtils.cs
@@ -1,0 +1,21 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+internal static class BooleanTypeUtils
+{
+	internal static IPropertyResolver ValidateBoolOperand(
+		string resolverName,
+		string parameterName,
+		IPropertyResolver operand)
+	{
+		if (operand.ValueType != typeof(bool))
+		{
+			throw new ArgumentException(
+				$"{resolverName} requires {parameterName} to resolve to bool. Got '{operand.ValueType}'.",
+				parameterName);
+		}
+
+		return operand;
+	}
+}

--- a/Forge/Statescript/Properties/NotResolver.cs
+++ b/Forge/Statescript/Properties/NotResolver.cs
@@ -1,0 +1,23 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the logical negation of a single nested <see cref="IPropertyResolver"/> operand. The operand must resolve
+/// to <see cref="bool"/>.
+/// </summary>
+/// <param name="operand">The resolver for the operand to negate.</param>
+public class NotResolver(IPropertyResolver operand) : IPropertyResolver
+{
+	private readonly IPropertyResolver _operand =
+		BooleanTypeUtils.ValidateBoolOperand(nameof(NotResolver), nameof(operand), operand);
+
+	/// <inheritdoc/>
+	public Type ValueType => typeof(bool);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		return new Variant128(!_operand.Resolve(graphContext).AsBool());
+	}
+}

--- a/Forge/Statescript/Properties/OrResolver.cs
+++ b/Forge/Statescript/Properties/OrResolver.cs
@@ -1,0 +1,33 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the logical disjunction of two nested <see cref="IPropertyResolver"/> operands. Both operands must resolve
+/// to <see cref="bool"/>.
+/// </summary>
+/// <remarks>
+/// Both operands are resolved on every call before applying the boolean operator.
+/// </remarks>
+/// <param name="left">The resolver for the left operand.</param>
+/// <param name="right">The resolver for the right operand.</param>
+public class OrResolver(IPropertyResolver left, IPropertyResolver right) : IPropertyResolver
+{
+	private readonly IPropertyResolver _left =
+		BooleanTypeUtils.ValidateBoolOperand(nameof(OrResolver), nameof(left), left);
+
+	private readonly IPropertyResolver _right =
+		BooleanTypeUtils.ValidateBoolOperand(nameof(OrResolver), nameof(right), right);
+
+	/// <inheritdoc/>
+	public Type ValueType => typeof(bool);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		var leftValue = _left.Resolve(graphContext).AsBool();
+		var rightValue = _right.Resolve(graphContext).AsBool();
+
+		return new Variant128(leftValue || rightValue);
+	}
+}

--- a/Forge/Statescript/Properties/XorResolver.cs
+++ b/Forge/Statescript/Properties/XorResolver.cs
@@ -1,0 +1,33 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the logical exclusive OR of two nested <see cref="IPropertyResolver"/> operands. Both operands must
+/// resolve to <see cref="bool"/>.
+/// </summary>
+/// <remarks>
+/// Both operands are resolved on every call before applying the boolean operator.
+/// </remarks>
+/// <param name="left">The resolver for the left operand.</param>
+/// <param name="right">The resolver for the right operand.</param>
+public class XorResolver(IPropertyResolver left, IPropertyResolver right) : IPropertyResolver
+{
+	private readonly IPropertyResolver _left =
+		BooleanTypeUtils.ValidateBoolOperand(nameof(XorResolver), nameof(left), left);
+
+	private readonly IPropertyResolver _right =
+		BooleanTypeUtils.ValidateBoolOperand(nameof(XorResolver), nameof(right), right);
+
+	/// <inheritdoc/>
+	public Type ValueType => typeof(bool);
+
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		var leftValue = _left.Resolve(graphContext).AsBool();
+		var rightValue = _right.Resolve(graphContext).AsBool();
+
+		return new Variant128(leftValue ^ rightValue);
+	}
+}

--- a/docs/statescript/nodes/condition/expression-node.md
+++ b/docs/statescript/nodes/condition/expression-node.md
@@ -28,7 +28,7 @@ Evaluates a boolean input property to choose the output. This eliminates the nee
 |-------|-------|------|-------------|
 | 0 | Condition | `bool` | The expression to evaluate. |
 
-The condition can be bound to any resolver producing a `bool`: a [TagResolver](../../resolvers/tag-resolver.md), [ComparisonResolver](../../resolvers/comparison-resolver.md), [VariableResolver](../../resolvers/variable-resolver.md) (reading a bool variable), or a nested chain.
+The condition can be bound to any resolver producing a `bool`: a [TagResolver](../../resolvers/tag-resolver.md), [ComparisonResolver](../../resolvers/comparison-resolver.md), [AndResolver](../../resolvers/and-resolver.md), [OrResolver](../../resolvers/or-resolver.md), [NotResolver](../../resolvers/not-resolver.md), [XorResolver](../../resolvers/xor-resolver.md), [VariableResolver](../../resolvers/variable-resolver.md) (reading a bool variable), or a nested chain.
 
 ## Behavior
 
@@ -39,16 +39,19 @@ The condition can be bound to any resolver producing a `bool`: a [TagResolver](.
 ## Usage
 
 ```csharp
-// Define a comparison property
-graph.VariableDefinitions.DefineProperty("healthAboveHalf",
-    new ComparisonResolver(
-        new AttributeResolver("CombatAttributeSet.Health"),
-        ComparisonOperation.GreaterThan,
-        new VariantResolver(new Variant128(50), typeof(int))));
+// Define a composed boolean property
+graph.VariableDefinitions.DefineProperty("shouldUseStrongEffect",
+    new AndResolver(
+        new ComparisonResolver(
+            new AttributeResolver("CombatAttributeSet.Health"),
+            ComparisonOperation.GreaterThan,
+            new VariantResolver(new Variant128(50), typeof(int))),
+        new NotResolver(
+            new TagResolver(Tag.RequestTag(tagsManager, "status.silenced")))));
 
 // Create and bind the expression node
 var expression = new ExpressionNode();
-expression.BindInput(ExpressionNode.ConditionInput, "healthAboveHalf");
+expression.BindInput(ExpressionNode.ConditionInput, "shouldUseStrongEffect");
 
 graph.AddNode(expression);
 

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -12,12 +12,23 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 |----------|-------------|-------------|
 | [ArrayVariableResolver](array-resolver.md) | *(configured)* | Stores a mutable array of values with indexed access. |
 | [AttributeResolver](attribute-resolver.md) | `int` | Reads the current value of an entity attribute. |
-| [ComparisonResolver](comparison-resolver.md) | `bool` | Compares two values using a comparison operation. |
 | [MagnitudeResolver](magnitude-resolver.md) | `float` | Reads the magnitude from the ability activation context. |
 | [SharedVariableResolver](shared-variable-resolver.md) | *(configured)* | Reads a shared variable from the entity. |
 | [TagResolver](tag-resolver.md) | `bool` | Checks whether the owner entity has a specific tag. |
 | [VariableResolver](variable-resolver.md) | *(configured)* | Reads a graph variable by name. |
 | [VariantResolver](variant-resolver.md) | *(configured)* | Holds a fixed constant value. |
+
+---
+
+## Boolean Expressions
+
+| Resolver | Output Type | Description |
+|----------|-------------|-------------|
+| [AndResolver](and-resolver.md) | `bool` | Returns `true` only when both boolean operands are `true`. |
+| [ComparisonResolver](comparison-resolver.md) | `bool` | Compares two values using a comparison operation. |
+| [NotResolver](not-resolver.md) | `bool` | Returns the logical inverse of a boolean operand. |
+| [OrResolver](or-resolver.md) | `bool` | Returns `true` when either boolean operand is `true`. |
+| [XorResolver](xor-resolver.md) | `bool` | Returns `true` when exactly one boolean operand is `true`. |
 
 ---
 

--- a/docs/statescript/resolvers/and-resolver.md
+++ b/docs/statescript/resolvers/and-resolver.md
@@ -1,0 +1,56 @@
+# AndResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.AndResolver`
+> **Output Type:** `bool`
+
+Combines two boolean resolvers using logical AND and returns `true` only when both operands resolve to `true`.
+
+## Constructor
+
+```csharp
+new AndResolver(left, right)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| left | `IPropertyResolver` | The resolver for the left boolean operand. |
+| right | `IPropertyResolver` | The resolver for the right boolean operand. |
+
+## Behavior
+
+- Requires both operands to have `ValueType == typeof(bool)`.
+- Resolves both operands on each call.
+- Returns `true` only when both resolved values are `true`.
+- Throws `ArgumentException` if either operand does not resolve to `bool`.
+
+## Usage
+
+```csharp
+graph.VariableDefinitions.DefineProperty("canAttack",
+    new AndResolver(
+        new TagResolver(Tag.RequestTag(tagsManager, "state.ready")),
+        new ComparisonResolver(
+            new AttributeResolver("CombatAttributeSet.Stamina"),
+            ComparisonOperation.GreaterThan,
+            new VariantResolver(new Variant128(0), typeof(int)))));
+```
+
+## Composition
+
+```csharp
+graph.VariableDefinitions.DefineProperty("shouldUseHeavyAttack",
+    new AndResolver(
+        new ComparisonResolver(
+            new VariableResolver("comboCount", typeof(int)),
+            ComparisonOperation.GreaterThanOrEqual,
+            new VariantResolver(new Variant128(3), typeof(int))),
+        new NotResolver(
+            new TagResolver(Tag.RequestTag(tagsManager, "status.silenced")))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [OrResolver](or-resolver.md)
+- [NotResolver](not-resolver.md)
+- [ExpressionNode](../nodes/condition/expression-node.md)

--- a/docs/statescript/resolvers/not-resolver.md
+++ b/docs/statescript/resolvers/not-resolver.md
@@ -1,0 +1,52 @@
+# NotResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.NotResolver`
+> **Output Type:** `bool`
+
+Negates a boolean resolver and returns the logical inverse of its resolved value.
+
+## Constructor
+
+```csharp
+new NotResolver(operand)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| operand | `IPropertyResolver` | The resolver for the boolean operand to negate. |
+
+## Behavior
+
+- Requires the operand to have `ValueType == typeof(bool)`.
+- Resolves the operand on each call.
+- Returns `true` when the operand resolves to `false`.
+- Returns `false` when the operand resolves to `true`.
+- Throws `ArgumentException` if the operand does not resolve to `bool`.
+
+## Usage
+
+```csharp
+graph.VariableDefinitions.DefineProperty("isNotStunned",
+    new NotResolver(
+        new TagResolver(Tag.RequestTag(tagsManager, "status.stunned"))));
+```
+
+## Composition
+
+```csharp
+graph.VariableDefinitions.DefineProperty("canInteract",
+    new AndResolver(
+        new NotResolver(
+            new TagResolver(Tag.RequestTag(tagsManager, "status.disabled"))),
+        new ComparisonResolver(
+            new VariableResolver("distanceToTarget", typeof(float)),
+            ComparisonOperation.LessThanOrEqual,
+            new VariantResolver(new Variant128(3.0f), typeof(float)))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [AndResolver](and-resolver.md)
+- [OrResolver](or-resolver.md)
+- [ExpressionNode](../nodes/condition/expression-node.md)

--- a/docs/statescript/resolvers/or-resolver.md
+++ b/docs/statescript/resolvers/or-resolver.md
@@ -1,0 +1,58 @@
+# OrResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.OrResolver`
+> **Output Type:** `bool`
+
+Combines two boolean resolvers using logical OR and returns `true` when either operand resolves to `true`.
+
+## Constructor
+
+```csharp
+new OrResolver(left, right)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| left | `IPropertyResolver` | The resolver for the left boolean operand. |
+| right | `IPropertyResolver` | The resolver for the right boolean operand. |
+
+## Behavior
+
+- Requires both operands to have `ValueType == typeof(bool)`.
+- Resolves both operands on each call.
+- Returns `true` when either resolved value is `true`.
+- Returns `false` only when both resolved values are `false`.
+- Throws `ArgumentException` if either operand does not resolve to `bool`.
+
+## Usage
+
+```csharp
+graph.VariableDefinitions.DefineProperty("shouldRetreat",
+    new OrResolver(
+        new ComparisonResolver(
+            new AttributeResolver("CombatAttributeSet.Health"),
+            ComparisonOperation.LessThanOrEqual,
+            new VariantResolver(new Variant128(20), typeof(int))),
+        new TagResolver(Tag.RequestTag(tagsManager, "status.fleeing"))));
+```
+
+## Composition
+
+```csharp
+graph.VariableDefinitions.DefineProperty("canBypassLock",
+    new OrResolver(
+        new TagResolver(Tag.RequestTag(tagsManager, "key.master")),
+        new AndResolver(
+            new TagResolver(Tag.RequestTag(tagsManager, "skill.lockpicking")),
+            new ComparisonResolver(
+                new VariableResolver("lockpickLevel", typeof(int)),
+                ComparisonOperation.GreaterThanOrEqual,
+                new VariantResolver(new Variant128(5), typeof(int))))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [AndResolver](and-resolver.md)
+- [XorResolver](xor-resolver.md)
+- [ExpressionNode](../nodes/condition/expression-node.md)

--- a/docs/statescript/resolvers/xor-resolver.md
+++ b/docs/statescript/resolvers/xor-resolver.md
@@ -1,0 +1,53 @@
+# XorResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.XorResolver`
+> **Output Type:** `bool`
+
+Combines two boolean resolvers using logical exclusive OR and returns `true` when exactly one operand resolves to `true`.
+
+## Constructor
+
+```csharp
+new XorResolver(left, right)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| left | `IPropertyResolver` | The resolver for the left boolean operand. |
+| right | `IPropertyResolver` | The resolver for the right boolean operand. |
+
+## Behavior
+
+- Requires both operands to have `ValueType == typeof(bool)`.
+- Resolves both operands on each call.
+- Returns `true` when exactly one resolved value is `true`.
+- Returns `false` when both resolved values are the same.
+- Throws `ArgumentException` if either operand does not resolve to `bool`.
+
+## Usage
+
+```csharp
+graph.VariableDefinitions.DefineProperty("exactlyOneTriggerActive",
+    new XorResolver(
+        new VariableResolver("leftTriggerPressed", typeof(bool)),
+        new VariableResolver("rightTriggerPressed", typeof(bool))));
+```
+
+## Composition
+
+```csharp
+graph.VariableDefinitions.DefineProperty("shouldFlipState",
+    new XorResolver(
+        new ComparisonResolver(
+            new VariableResolver("currentPhase", typeof(int)),
+            ComparisonOperation.Equal,
+            new VariantResolver(new Variant128(1), typeof(int))),
+        new TagResolver(Tag.RequestTag(tagsManager, "state.inverted"))));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [AndResolver](and-resolver.md)
+- [OrResolver](or-resolver.md)
+- [ExpressionNode](../nodes/condition/expression-node.md)


### PR DESCRIPTION
Added boolean expression resolvers.

| Resolver | Output Type | Description |
|----------|-------------|-------------|
| AndResolver | `bool` | Returns `true` only when both boolean operands are `true`. |
| NotResolver | `bool` | Returns the logical inverse of a boolean operand. |
| OrResolver | `bool` | Returns `true` when either boolean operand is `true`. |
| XorResolver | `bool` | Returns `true` when exactly one boolean operand is `true`. |