### PR TITLE
Added component-wise support for DegToRad, RadToDeg and Pow resolvers.

### DIFF
--- a/Forge.Tests/Helpers/TestUtils.cs
+++ b/Forge.Tests/Helpers/TestUtils.cs
@@ -1,5 +1,6 @@
 // Copyright © Gamesmiths Guild.
 
+using System.Numerics;
 using FluentAssertions;
 using Gamesmiths.Forge.Core;
 using Gamesmiths.Forge.Effects;
@@ -72,5 +73,26 @@ public static class TestUtils
 		}
 
 		return tags;
+	}
+
+	public static void BeApproximately(Vector2 actual, Vector2 expected)
+	{
+		actual.X.Should().BeApproximately(expected.X, Tolerance);
+		actual.Y.Should().BeApproximately(expected.Y, Tolerance);
+	}
+
+	public static void BeApproximately(Vector3 actual, Vector3 expected)
+	{
+		actual.X.Should().BeApproximately(expected.X, Tolerance);
+		actual.Y.Should().BeApproximately(expected.Y, Tolerance);
+		actual.Z.Should().BeApproximately(expected.Z, Tolerance);
+	}
+
+	public static void BeApproximately(Vector4 actual, Vector4 expected)
+	{
+		actual.X.Should().BeApproximately(expected.X, Tolerance);
+		actual.Y.Should().BeApproximately(expected.Y, Tolerance);
+		actual.Z.Should().BeApproximately(expected.Z, Tolerance);
+		actual.W.Should().BeApproximately(expected.W, Tolerance);
 	}
 }

--- a/Forge.Tests/Statescript/Resolvers/DegToRadResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/DegToRadResolverTests.cs
@@ -154,11 +154,63 @@ public class DegToRadResolverTests
 
 	[Fact]
 	[Trait("Resolver", "DegToRad")]
-	public void DegToRad_resolver_throws_for_vector_operand()
+	public void DegToRad_resolver_vector3_value_type_is_vector3()
+	{
+		var resolver = new DegToRadResolver(
+			new VariantResolver(new Variant128(new Vector3(90.0f, 180.0f, 360.0f)), typeof(Vector3)));
+
+		resolver.ValueType.Should().Be(typeof(Vector3));
+	}
+
+	[Fact]
+	[Trait("Resolver", "DegToRad")]
+	public void DegToRad_resolver_vector2_computes_componentwise_conversion()
+	{
+		var resolver = new DegToRadResolver(
+			new VariantResolver(new Variant128(new Vector2(45.0f, 90.0f)), typeof(Vector2)));
+
+		var context = new GraphContext();
+
+		TestUtils.BeApproximately(
+			resolver.Resolve(context).AsVector2(),
+			new Vector2(MathF.PI / 4.0f, MathF.PI / 2.0f));
+	}
+
+	[Fact]
+	[Trait("Resolver", "DegToRad")]
+	public void DegToRad_resolver_vector3_computes_componentwise_conversion()
+	{
+		var resolver = new DegToRadResolver(
+			new VariantResolver(new Variant128(new Vector3(90.0f, 180.0f, 360.0f)), typeof(Vector3)));
+
+		var context = new GraphContext();
+
+		TestUtils.BeApproximately(
+			resolver.Resolve(context).AsVector3(),
+			new Vector3(MathF.PI / 2.0f, MathF.PI, 2.0f * MathF.PI));
+	}
+
+	[Fact]
+	[Trait("Resolver", "DegToRad")]
+	public void DegToRad_resolver_vector4_computes_componentwise_conversion()
+	{
+		var resolver = new DegToRadResolver(
+			new VariantResolver(new Variant128(new Vector4(0.0f, 90.0f, 180.0f, 360.0f)), typeof(Vector4)));
+
+		var context = new GraphContext();
+
+		TestUtils.BeApproximately(
+			resolver.Resolve(context).AsVector4(),
+			new Vector4(0.0f, MathF.PI / 2.0f, MathF.PI, 2.0f * MathF.PI));
+	}
+
+	[Fact]
+	[Trait("Resolver", "DegToRad")]
+	public void DegToRad_resolver_throws_for_quaternion_operand()
 	{
 #pragma warning disable CA1806
 		Action act = () => new DegToRadResolver(
-			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+		 new VariantResolver(new Variant128(Quaternion.Identity), typeof(Quaternion)));
 #pragma warning restore CA1806
 
 		act.Should().Throw<ArgumentException>();

--- a/Forge.Tests/Statescript/Resolvers/PowResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/PowResolverTests.cs
@@ -166,11 +166,61 @@ public class PowResolverTests
 
 	[Fact]
 	[Trait("Resolver", "Pow")]
-	public void Pow_resolver_throws_for_vector_operands()
+	public void Pow_resolver_vector3_operands_value_type_is_vector3()
+	{
+		var resolver = new PowResolver(
+			new VariantResolver(new Variant128(new Vector3(2.0f, 3.0f, 4.0f)), typeof(Vector3)),
+			new VariantResolver(new Variant128(new Vector3(3.0f, 2.0f, 0.5f)), typeof(Vector3)));
+
+		resolver.ValueType.Should().Be(typeof(Vector3));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pow")]
+	public void Pow_resolver_vector2_computes_componentwise_power()
+	{
+		var resolver = new PowResolver(
+			new VariantResolver(new Variant128(new Vector2(4.0f, 9.0f)), typeof(Vector2)),
+			new VariantResolver(new Variant128(new Vector2(0.5f, 0.5f)), typeof(Vector2)));
+
+		var context = new GraphContext();
+
+		TestUtils.BeApproximately(resolver.Resolve(context).AsVector2(), new Vector2(2.0f, 3.0f));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pow")]
+	public void Pow_resolver_vector3_computes_componentwise_power()
+	{
+		var resolver = new PowResolver(
+			new VariantResolver(new Variant128(new Vector3(2.0f, 3.0f, 4.0f)), typeof(Vector3)),
+			new VariantResolver(new Variant128(new Vector3(3.0f, 2.0f, 0.5f)), typeof(Vector3)));
+
+		var context = new GraphContext();
+
+		TestUtils.BeApproximately(resolver.Resolve(context).AsVector3(), new Vector3(8.0f, 9.0f, 2.0f));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pow")]
+	public void Pow_resolver_vector4_computes_componentwise_power()
+	{
+		var resolver = new PowResolver(
+			new VariantResolver(new Variant128(new Vector4(1.0f, 4.0f, 9.0f, 16.0f)), typeof(Vector4)),
+			new VariantResolver(new Variant128(new Vector4(2.0f, 0.5f, 0.5f, 0.5f)), typeof(Vector4)));
+
+		var context = new GraphContext();
+
+		TestUtils.BeApproximately(resolver.Resolve(context).AsVector4(), new Vector4(1.0f, 2.0f, 3.0f, 4.0f));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pow")]
+	public void Pow_resolver_throws_for_mismatched_vector_operands()
 	{
 #pragma warning disable CA1806
 		Action act = () => new PowResolver(
-			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)),
+			new VariantResolver(new Variant128(Vector2.One), typeof(Vector2)),
 			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
 #pragma warning restore CA1806
 

--- a/Forge.Tests/Statescript/Resolvers/PowResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/PowResolverTests.cs
@@ -170,7 +170,18 @@ public class PowResolverTests
 	{
 		var resolver = new PowResolver(
 			new VariantResolver(new Variant128(new Vector3(2.0f, 3.0f, 4.0f)), typeof(Vector3)),
-			new VariantResolver(new Variant128(new Vector3(3.0f, 2.0f, 0.5f)), typeof(Vector3)));
+			new VariantResolver(new Variant128(2.0f), typeof(float)));
+
+		resolver.ValueType.Should().Be(typeof(Vector3));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pow")]
+	public void Pow_resolver_vector_base_with_double_exponent_value_type_is_vector3()
+	{
+		var resolver = new PowResolver(
+			new VariantResolver(new Variant128(new Vector3(2.0f, 3.0f, 4.0f)), typeof(Vector3)),
+			new VariantResolver(new Variant128(2.0), typeof(double)));
 
 		resolver.ValueType.Should().Be(typeof(Vector3));
 	}
@@ -181,11 +192,11 @@ public class PowResolverTests
 	{
 		var resolver = new PowResolver(
 			new VariantResolver(new Variant128(new Vector2(4.0f, 9.0f)), typeof(Vector2)),
-			new VariantResolver(new Variant128(new Vector2(0.5f, 0.5f)), typeof(Vector2)));
+			new VariantResolver(new Variant128(2.0f), typeof(float)));
 
 		var context = new GraphContext();
 
-		TestUtils.BeApproximately(resolver.Resolve(context).AsVector2(), new Vector2(2.0f, 3.0f));
+		TestUtils.BeApproximately(resolver.Resolve(context).AsVector2(), new Vector2(16.0f, 81.0f));
 	}
 
 	[Fact]
@@ -194,11 +205,11 @@ public class PowResolverTests
 	{
 		var resolver = new PowResolver(
 			new VariantResolver(new Variant128(new Vector3(2.0f, 3.0f, 4.0f)), typeof(Vector3)),
-			new VariantResolver(new Variant128(new Vector3(3.0f, 2.0f, 0.5f)), typeof(Vector3)));
+			new VariantResolver(new Variant128(2f), typeof(float)));
 
 		var context = new GraphContext();
 
-		TestUtils.BeApproximately(resolver.Resolve(context).AsVector3(), new Vector3(8.0f, 9.0f, 2.0f));
+		TestUtils.BeApproximately(resolver.Resolve(context).AsVector3(), new Vector3(4.0f, 9.0f, 16.0f));
 	}
 
 	[Fact]
@@ -207,11 +218,37 @@ public class PowResolverTests
 	{
 		var resolver = new PowResolver(
 			new VariantResolver(new Variant128(new Vector4(1.0f, 4.0f, 9.0f, 16.0f)), typeof(Vector4)),
-			new VariantResolver(new Variant128(new Vector4(2.0f, 0.5f, 0.5f, 0.5f)), typeof(Vector4)));
+			new VariantResolver(new Variant128(2.0f), typeof(float)));
 
 		var context = new GraphContext();
 
-		TestUtils.BeApproximately(resolver.Resolve(context).AsVector4(), new Vector4(1.0f, 2.0f, 3.0f, 4.0f));
+		TestUtils.BeApproximately(resolver.Resolve(context).AsVector4(), new Vector4(1.0f, 16.0f, 81.0f, 256.0f));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pow")]
+	public void Pow_resolver_vector_base_with_double_exponent_computes_componentwise_power()
+	{
+		var resolver = new PowResolver(
+			new VariantResolver(new Variant128(new Vector3(4.0f, 9.0f, 16.0f)), typeof(Vector3)),
+			new VariantResolver(new Variant128(0.5), typeof(double)));
+
+		var context = new GraphContext();
+
+		TestUtils.BeApproximately(resolver.Resolve(context).AsVector3(), new Vector3(2.0f, 3.0f, 4.0f));
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pow")]
+	public void Pow_resolver_vector_base_with_int_exponent_computes_componentwise_power()
+	{
+		var resolver = new PowResolver(
+			new VariantResolver(new Variant128(new Vector3(2.0f, 3.0f, 4.0f)), typeof(Vector3)),
+			new VariantResolver(new Variant128(2), typeof(int)));
+
+		var context = new GraphContext();
+
+		TestUtils.BeApproximately(resolver.Resolve(context).AsVector3(), new Vector3(4.0f, 9.0f, 16.0f));
 	}
 
 	[Fact]
@@ -224,7 +261,39 @@ public class PowResolverTests
 			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
 #pragma warning restore CA1806
 
-		act.Should().Throw<ArgumentException>();
+		act.Should()
+			.Throw<ArgumentException>()
+			.WithMessage("*requires a scalar numeric exponent when the base is a vector*");
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pow")]
+	public void Pow_resolver_throws_for_vector_exponent()
+	{
+#pragma warning disable CA1806
+		Action act = () => new PowResolver(
+			new VariantResolver(new Variant128(new Vector3(2.0f, 3.0f, 4.0f)), typeof(Vector3)),
+			new VariantResolver(new Variant128(new Vector3(2.0f, 2.0f, 2.0f)), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should()
+			.Throw<ArgumentException>()
+			.WithMessage("*requires a scalar numeric exponent when the base is a vector*");
+	}
+
+	[Fact]
+	[Trait("Resolver", "Pow")]
+	public void Pow_resolver_throws_for_scalar_base_with_vector_exponent()
+	{
+#pragma warning disable CA1806
+		Action act = () => new PowResolver(
+			new VariantResolver(new Variant128(2.0f), typeof(float)),
+			new VariantResolver(new Variant128(new Vector3(2.0f, 3.0f, 4.0f)), typeof(Vector3)));
+#pragma warning restore CA1806
+
+		act.Should()
+			.Throw<ArgumentException>()
+			.WithMessage("*does not support scalar bases with vector or quaternion exponents*");
 	}
 
 	[Fact]

--- a/Forge.Tests/Statescript/Resolvers/RadToDegResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/RadToDegResolverTests.cs
@@ -152,11 +152,60 @@ public class RadToDegResolverTests
 
 	[Fact]
 	[Trait("Resolver", "RadToDeg")]
-	public void RadToDeg_resolver_throws_for_vector_operand()
+	public void RadToDeg_resolver_vector3_value_type_is_vector3()
+	{
+		var resolver = new RadToDegResolver(
+			new VariantResolver(
+				new Variant128(new Vector3(MathF.PI / 2.0f, MathF.PI, 2.0f * MathF.PI)), typeof(Vector3)));
+
+		resolver.ValueType.Should().Be(typeof(Vector3));
+	}
+
+	[Fact]
+	[Trait("Resolver", "RadToDeg")]
+	public void RadToDeg_resolver_vector2_computes_componentwise_conversion()
+	{
+		var resolver = new RadToDegResolver(
+			new VariantResolver(new Variant128(new Vector2(MathF.PI / 4.0f, MathF.PI / 2.0f)), typeof(Vector2)));
+
+		var context = new GraphContext();
+
+		TestUtils.BeApproximately(resolver.Resolve(context).AsVector2(), new Vector2(45.0f, 90.0f));
+	}
+
+	[Fact]
+	[Trait("Resolver", "RadToDeg")]
+	public void RadToDeg_resolver_vector3_computes_componentwise_conversion()
+	{
+		var resolver = new RadToDegResolver(
+			new VariantResolver(
+				new Variant128(new Vector3(MathF.PI / 2.0f, MathF.PI, 2.0f * MathF.PI)), typeof(Vector3)));
+
+		var context = new GraphContext();
+
+		TestUtils.BeApproximately(resolver.Resolve(context).AsVector3(), new Vector3(90.0f, 180.0f, 360.0f));
+	}
+
+	[Fact]
+	[Trait("Resolver", "RadToDeg")]
+	public void RadToDeg_resolver_vector4_computes_componentwise_conversion()
+	{
+		var resolver = new RadToDegResolver(
+			new VariantResolver(
+				new Variant128(new Vector4(0.0f, MathF.PI / 2.0f, MathF.PI, 2.0f * MathF.PI)), typeof(Vector4)));
+
+		var context = new GraphContext();
+
+		TestUtils.BeApproximately(resolver.Resolve(context).AsVector4(), new Vector4(0.0f, 90.0f, 180.0f, 360.0f));
+	}
+
+	[Fact]
+	[Trait("Resolver", "RadToDeg")]
+	public void RadToDeg_resolver_throws_for_quaternion_operand()
 	{
 #pragma warning disable CA1806
 		Action act = () => new RadToDegResolver(
-			new VariantResolver(new Variant128(Vector3.One), typeof(Vector3)));
+			new VariantResolver(new Variant128(Quaternion.Identity), typeof(Quaternion)));
 #pragma warning restore CA1806
 
 		act.Should().Throw<ArgumentException>();

--- a/Forge/Statescript/Properties/DegToRadResolver.cs
+++ b/Forge/Statescript/Properties/DegToRadResolver.cs
@@ -1,11 +1,14 @@
 // Copyright © Gamesmiths Guild.
 
+using System.Numerics;
+
 namespace Gamesmiths.Forge.Statescript.Properties;
 
 /// <summary>
 /// Resolves a conversion from degrees to radians using a single <see cref="IPropertyResolver"/> operand. Computes
-/// <c>degrees * (π / 180)</c>. Supports <see langword="float"/> and <see langword="double"/> types. Integer operand
-/// types are promoted to <see langword="double"/>. Decimal, vector, and quaternion types are not supported.
+/// <c>degrees * (π / 180)</c>. Supports <see langword="float"/> and <see langword="double"/> types as well as
+/// component-wise conversion for <see cref="Vector2"/>, <see cref="Vector3"/>, and <see cref="Vector4"/>. Integer
+/// operand types are promoted to <see langword="double"/>. Decimal and quaternion types are not supported.
 /// </summary>
 /// <param name="operand">The resolver for the operand (angle in degrees).</param>
 public class DegToRadResolver(IPropertyResolver operand) : IPropertyResolver
@@ -13,9 +16,7 @@ public class DegToRadResolver(IPropertyResolver operand) : IPropertyResolver
 	private readonly IPropertyResolver _operand = operand;
 
 	/// <inheritdoc/>
-	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointPromotedUnaryResultType(
-		nameof(DegToRadResolver),
-		operand.ValueType);
+	public Type ValueType { get; } = DetermineResultType(operand.ValueType);
 
 	/// <inheritdoc/>
 	public Variant128 Resolve(GraphContext graphContext)
@@ -34,7 +35,34 @@ public class DegToRadResolver(IPropertyResolver operand) : IPropertyResolver
 				MathTypeUtils.ResolveAsDouble(_operand.ValueType, value) * (Math.PI / 180.0));
 		}
 
+		if (resultType == typeof(Vector2))
+		{
+			return new Variant128(value.AsVector2() * (MathF.PI / 180.0f));
+		}
+
+		if (resultType == typeof(Vector3))
+		{
+			return new Variant128(value.AsVector3() * (MathF.PI / 180.0f));
+		}
+
+		if (resultType == typeof(Vector4))
+		{
+			return new Variant128(value.AsVector4() * (MathF.PI / 180.0f));
+		}
+
 		throw new InvalidOperationException(
 			$"DegToRadResolver encountered unexpected result type '{resultType}'.");
+	}
+
+	private static Type DetermineResultType(Type operandType)
+	{
+		if (MathTypeUtils.IsVectorType(operandType))
+		{
+			return operandType;
+		}
+
+		return MathTypeUtils.DetermineFloatingPointPromotedUnaryResultType(
+			nameof(DegToRadResolver),
+			operandType);
 	}
 }

--- a/Forge/Statescript/Properties/PowResolver.cs
+++ b/Forge/Statescript/Properties/PowResolver.cs
@@ -1,11 +1,14 @@
 // Copyright © Gamesmiths Guild.
 
+using System.Numerics;
+
 namespace Gamesmiths.Forge.Statescript.Properties;
 
 /// <summary>
 /// Resolves a value raised to a specified power using two nested <see cref="IPropertyResolver"/> operands. Supports
-/// <see langword="float"/> and <see langword="double"/> types. Integer operand types are promoted to
-/// <see langword="double"/>. Decimal, vector, and quaternion types are not supported.
+/// <see langword="float"/> and <see langword="double"/> types as well as component-wise operations for
+/// <see cref="Vector2"/>, <see cref="Vector3"/>, and <see cref="Vector4"/>. Integer operand types are promoted to
+/// <see langword="double"/>. Decimal and quaternion types are not supported.
 /// </summary>
 /// <param name="baseOperand">The resolver for the base operand.</param>
 /// <param name="exponent">The resolver for the exponent operand.</param>
@@ -16,10 +19,7 @@ public class PowResolver(IPropertyResolver baseOperand, IPropertyResolver expone
 	private readonly IPropertyResolver _exponent = exponent;
 
 	/// <inheritdoc/>
-	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointBinaryResultType(
-		nameof(PowResolver),
-		baseOperand.ValueType,
-		exponent.ValueType);
+	public Type ValueType { get; } = DetermineResultType(baseOperand.ValueType, exponent.ValueType);
 
 	/// <inheritdoc/>
 	public Variant128 Resolve(GraphContext graphContext)
@@ -44,6 +44,49 @@ public class PowResolver(IPropertyResolver baseOperand, IPropertyResolver expone
 					MathTypeUtils.ResolveAsDouble(_exponent.ValueType, expValue)));
 		}
 
+		if (resultType == typeof(Vector2))
+		{
+			Vector2 baseVector = baseValue.AsVector2();
+			Vector2 exponentVector = expValue.AsVector2();
+			return new Variant128(new Vector2(
+				MathF.Pow(baseVector.X, exponentVector.X),
+				MathF.Pow(baseVector.Y, exponentVector.Y)));
+		}
+
+		if (resultType == typeof(Vector3))
+		{
+			Vector3 baseVector = baseValue.AsVector3();
+			Vector3 exponentVector = expValue.AsVector3();
+			return new Variant128(new Vector3(
+				MathF.Pow(baseVector.X, exponentVector.X),
+				MathF.Pow(baseVector.Y, exponentVector.Y),
+				MathF.Pow(baseVector.Z, exponentVector.Z)));
+		}
+
+		if (resultType == typeof(Vector4))
+		{
+			Vector4 baseVector = baseValue.AsVector4();
+			Vector4 exponentVector = expValue.AsVector4();
+			return new Variant128(new Vector4(
+				MathF.Pow(baseVector.X, exponentVector.X),
+				MathF.Pow(baseVector.Y, exponentVector.Y),
+				MathF.Pow(baseVector.Z, exponentVector.Z),
+				MathF.Pow(baseVector.W, exponentVector.W)));
+		}
+
 		throw new InvalidOperationException($"PowResolver encountered unexpected result type '{resultType}'.");
+	}
+
+	private static Type DetermineResultType(Type baseType, Type exponentType)
+	{
+		if (baseType == exponentType && MathTypeUtils.IsVectorType(baseType))
+		{
+			return baseType;
+		}
+
+		return MathTypeUtils.DetermineFloatingPointBinaryResultType(
+			nameof(PowResolver),
+			baseType,
+			exponentType);
 	}
 }

--- a/Forge/Statescript/Properties/PowResolver.cs
+++ b/Forge/Statescript/Properties/PowResolver.cs
@@ -47,31 +47,31 @@ public class PowResolver(IPropertyResolver baseOperand, IPropertyResolver expone
 		if (resultType == typeof(Vector2))
 		{
 			Vector2 baseVector = baseValue.AsVector2();
-			Vector2 exponentVector = expValue.AsVector2();
+			float exp = (float)MathTypeUtils.ResolveAsDouble(_exponent.ValueType, expValue);
 			return new Variant128(new Vector2(
-				MathF.Pow(baseVector.X, exponentVector.X),
-				MathF.Pow(baseVector.Y, exponentVector.Y)));
+				MathF.Pow(baseVector.X, exp),
+				MathF.Pow(baseVector.Y, exp)));
 		}
 
 		if (resultType == typeof(Vector3))
 		{
 			Vector3 baseVector = baseValue.AsVector3();
-			Vector3 exponentVector = expValue.AsVector3();
+			float exp = (float)MathTypeUtils.ResolveAsDouble(_exponent.ValueType, expValue);
 			return new Variant128(new Vector3(
-				MathF.Pow(baseVector.X, exponentVector.X),
-				MathF.Pow(baseVector.Y, exponentVector.Y),
-				MathF.Pow(baseVector.Z, exponentVector.Z)));
+				MathF.Pow(baseVector.X, exp),
+				MathF.Pow(baseVector.Y, exp),
+				MathF.Pow(baseVector.Z, exp)));
 		}
 
 		if (resultType == typeof(Vector4))
 		{
 			Vector4 baseVector = baseValue.AsVector4();
-			Vector4 exponentVector = expValue.AsVector4();
+			float exp = (float)MathTypeUtils.ResolveAsDouble(_exponent.ValueType, expValue);
 			return new Variant128(new Vector4(
-				MathF.Pow(baseVector.X, exponentVector.X),
-				MathF.Pow(baseVector.Y, exponentVector.Y),
-				MathF.Pow(baseVector.Z, exponentVector.Z),
-				MathF.Pow(baseVector.W, exponentVector.W)));
+				MathF.Pow(baseVector.X, exp),
+				MathF.Pow(baseVector.Y, exp),
+				MathF.Pow(baseVector.Z, exp),
+				MathF.Pow(baseVector.W, exp)));
 		}
 
 		throw new InvalidOperationException($"PowResolver encountered unexpected result type '{resultType}'.");
@@ -79,9 +79,32 @@ public class PowResolver(IPropertyResolver baseOperand, IPropertyResolver expone
 
 	private static Type DetermineResultType(Type baseType, Type exponentType)
 	{
-		if (baseType == exponentType && MathTypeUtils.IsVectorType(baseType))
+		if (MathTypeUtils.IsVectorType(baseType))
 		{
+			if (MathTypeUtils.IsVectorOrQuaternionType(exponentType))
+			{
+				throw new ArgumentException(
+					$"PowResolver requires a scalar numeric exponent when the base is a vector. Got base '{baseType}' and exponent '{exponentType}'.");
+			}
+
+			if (!MathTypeUtils.IsNumericType(exponentType))
+			{
+				throw new ArgumentException(
+					$"PowResolver does not support exponent type '{exponentType}'.");
+			}
+
+			if (exponentType == typeof(decimal))
+			{
+				throw new ArgumentException("PowResolver does not support decimal operands. Use double instead.");
+			}
+
 			return baseType;
+		}
+
+		if (MathTypeUtils.IsVectorOrQuaternionType(exponentType))
+		{
+			throw new ArgumentException(
+				$"PowResolver does not support scalar bases with vector or quaternion exponents. Got base '{baseType}' and exponent '{exponentType}'.");
 		}
 
 		return MathTypeUtils.DetermineFloatingPointBinaryResultType(

--- a/Forge/Statescript/Properties/PowResolver.cs
+++ b/Forge/Statescript/Properties/PowResolver.cs
@@ -84,7 +84,8 @@ public class PowResolver(IPropertyResolver baseOperand, IPropertyResolver expone
 			if (MathTypeUtils.IsVectorOrQuaternionType(exponentType))
 			{
 				throw new ArgumentException(
-					$"PowResolver requires a scalar numeric exponent when the base is a vector. Got base '{baseType}' and exponent '{exponentType}'.");
+					"PowResolver requires a scalar numeric exponent when the base is a vector. Got base" +
+					$" '{baseType}' and exponent '{exponentType}'.");
 			}
 
 			if (!MathTypeUtils.IsNumericType(exponentType))
@@ -104,7 +105,8 @@ public class PowResolver(IPropertyResolver baseOperand, IPropertyResolver expone
 		if (MathTypeUtils.IsVectorOrQuaternionType(exponentType))
 		{
 			throw new ArgumentException(
-				$"PowResolver does not support scalar bases with vector or quaternion exponents. Got base '{baseType}' and exponent '{exponentType}'.");
+				"PowResolver does not support scalar bases with vector or quaternion exponents. Got base " +
+				$"'{baseType}' and exponent '{exponentType}'.");
 		}
 
 		return MathTypeUtils.DetermineFloatingPointBinaryResultType(

--- a/Forge/Statescript/Properties/RadToDegResolver.cs
+++ b/Forge/Statescript/Properties/RadToDegResolver.cs
@@ -1,11 +1,14 @@
 // Copyright © Gamesmiths Guild.
 
+using System.Numerics;
+
 namespace Gamesmiths.Forge.Statescript.Properties;
 
 /// <summary>
 /// Resolves a conversion from radians to degrees using a single <see cref="IPropertyResolver"/> operand. Computes
-/// <c>radians * (180 / π)</c>. Supports <see langword="float"/> and <see langword="double"/> types. Integer operand
-/// types are promoted to <see langword="double"/>. Decimal, vector, and quaternion types are not supported.
+/// <c>radians * (180 / π)</c>. Supports <see langword="float"/> and <see langword="double"/> types as well as
+/// component-wise conversion for <see cref="Vector2"/>, <see cref="Vector3"/>, and <see cref="Vector4"/>. Integer
+/// operand types are promoted to <see langword="double"/>. Decimal and quaternion types are not supported.
 /// </summary>
 /// <param name="operand">The resolver for the operand (angle in radians).</param>
 public class RadToDegResolver(IPropertyResolver operand) : IPropertyResolver
@@ -13,9 +16,7 @@ public class RadToDegResolver(IPropertyResolver operand) : IPropertyResolver
 	private readonly IPropertyResolver _operand = operand;
 
 	/// <inheritdoc/>
-	public Type ValueType { get; } = MathTypeUtils.DetermineFloatingPointPromotedUnaryResultType(
-		nameof(RadToDegResolver),
-		operand.ValueType);
+	public Type ValueType { get; } = DetermineResultType(operand.ValueType);
 
 	/// <inheritdoc/>
 	public Variant128 Resolve(GraphContext graphContext)
@@ -34,7 +35,34 @@ public class RadToDegResolver(IPropertyResolver operand) : IPropertyResolver
 				MathTypeUtils.ResolveAsDouble(_operand.ValueType, value) * (180.0 / Math.PI));
 		}
 
+		if (resultType == typeof(Vector2))
+		{
+			return new Variant128(value.AsVector2() * (180.0f / MathF.PI));
+		}
+
+		if (resultType == typeof(Vector3))
+		{
+			return new Variant128(value.AsVector3() * (180.0f / MathF.PI));
+		}
+
+		if (resultType == typeof(Vector4))
+		{
+			return new Variant128(value.AsVector4() * (180.0f / MathF.PI));
+		}
+
 		throw new InvalidOperationException(
 			$"RadToDegResolver encountered unexpected result type '{resultType}'.");
+	}
+
+	private static Type DetermineResultType(Type operandType)
+	{
+		if (MathTypeUtils.IsVectorType(operandType))
+		{
+			return operandType;
+		}
+
+		return MathTypeUtils.DetermineFloatingPointPromotedUnaryResultType(
+			nameof(RadToDegResolver),
+			operandType);
 	}
 }

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -49,15 +49,12 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [CopySignResolver](copysign-resolver.md) | `float`/`double` | Returns a value with the magnitude of one operand and the sign of another. |
 | [CosHResolver](cosh-resolver.md) | `float`/`double` | Computes the hyperbolic cosine. |
 | [CosResolver](cos-resolver.md) | `float`/`double` | Computes the cosine of an angle in radians. |
-| [DegToRadResolver](degtorad-resolver.md) | `float`/`double` | Converts degrees to radians. |
 | [EResolver](e-resolver.md) | `float`/`double` | Returns the mathematical constant `e` (Euler's number). |
 | [ExpResolver](exp-resolver.md) | `float`/`double` | Computes `e` raised to a specified power (`e^x`). |
 | [Log10Resolver](log10-resolver.md) | `float`/`double` | Computes the base-10 logarithm. |
 | [Log2Resolver](log2-resolver.md) | `float`/`double` | Computes the base-2 logarithm. |
 | [LogResolver](log-resolver.md) | `float`/`double` | Computes the natural logarithm (base `e`). |
 | [PiResolver](pi-resolver.md) | `float`/`double` | Returns the mathematical constant π (pi). |
-| [PowResolver](pow-resolver.md) | `float`/`double` | Raises a value to a specified power. |
-| [RadToDegResolver](radtodeg-resolver.md) | `float`/`double` | Converts radians to degrees. |
 | [SignResolver](sign-resolver.md) | `int` | Returns -1, 0, or 1 indicating the sign of a numeric value. |
 | [SinHResolver](sinh-resolver.md) | `float`/`double` | Computes the hyperbolic sine. |
 | [SinResolver](sin-resolver.md) | `float`/`double` | Computes the sine of an angle in radians. |
@@ -74,16 +71,19 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [AddResolver](add-resolver.md) | *(promoted or same vector type)* | Adds two numeric, vector or quaternion values. |
 | [CeilResolver](ceil-resolver.md) | *(same)* | Rounds up to the smallest integer greater than or equal to the operand. |
 | [ClampResolver](clamp-resolver.md) | *(promoted or same vector type)* | Clamps a numeric value or vector components between minimum and maximum bounds. |
+| [DegToRadResolver](degtorad-resolver.md) | `float`/`double`/`Vector2`/`Vector3`/`Vector4` | Converts degrees to radians. |
 | [DivideResolver](divide-resolver.md) | *(promoted or same vector type)* | Divides two numeric values, vectors component-wise, or two quaternions. |
 | [FloorResolver](floor-resolver.md) | *(same)* | Rounds down to the largest integer less than or equal to the operand. |
-| [LerpResolver](lerp-resolver.md) | `float`/`double`/`vector`/`quaternion` | Linearly interpolates between two values (scalar, vector, or quaternion). |
+| [LerpResolver](lerp-resolver.md) | `float`/`double`/`vector2`/`vector3`/`vector4`/`quaternion` | Linearly interpolates between two values (scalar, vector, or quaternion). |
 | [MaxResolver](max-resolver.md) | *(promoted or same vector type)* | Returns the larger of two numeric values or the component-wise maximum of two vectors. |
 | [MinResolver](min-resolver.md) | *(promoted or same vector type)* | Returns the smaller of two numeric values or the component-wise minimum of two vectors. |
 | [ModuloResolver](modulo-resolver.md) | *(promoted)* | Computes the remainder of dividing two numeric values. |
 | [MultiplyResolver](multiply-resolver.md) | *(promoted or same vector type)* | Multiplies two numeric, vectors component-wise, or two quaternions. |
 | [NegateResolver](negate-resolver.md) | *(promoted)* | Negates a numeric or vector value. |
+| [PowResolver](pow-resolver.md) | `float`/`double`/`Vector2`/`Vector3`/`Vector4` | Raises a value to a specified power. |
+| [RadToDegResolver](radtodeg-resolver.md) | `float`/`double`/`Vector2`/`Vector3`/`Vector4` | Converts radians to degrees. |
 | [RoundResolver](round-resolver.md) | *(same)* | Rounds to a specified number of digits with configurable rounding mode. |
-| [SqrtResolver](sqrt-resolver.md) | `float`/`double`/`vector` | Computes the square root of a numeric value or component-wise square root of a vector. |
+| [SqrtResolver](sqrt-resolver.md) | `float`/`double`/`vector2`/`vector3`/`vector4` | Computes the square root of a numeric value or component-wise square root of a vector. |
 | [SubtractResolver](subtract-resolver.md) | *(promoted or same vector type)* | Subtracts two numeric, vector or quaternion values. |
 | [TruncateResolver](truncate-resolver.md) | *(same)* | Removes the fractional part, rounding toward zero. |
 
@@ -103,7 +103,7 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [DotResolver](dot-resolver.md) | `float` | Computes the dot product of two vectors or two quaternions. |
 | [LengthResolver](length-resolver.md) | `float` | Computes the length (magnitude) of a vector or quaternion operand. |
 | [LengthSquaredResolver](lengthsquared-resolver.md) | `float` | Computes the squared length of a vector or quaternion operand. |
-| [NormalizeResolver](normalize-resolver.md) | `vector`/`plane`/`quaternion` | Computes the normalized form of a vector, plane, or quaternion. |
+| [NormalizeResolver](normalize-resolver.md) | `vector2`/`vector3`/`vector4`/`plane`/`quaternion` | Computes the normalized form of a vector, plane, or quaternion. |
 | [ProjectResolver](project-resolver.md) | `Vector2`/`Vector3`/`Vector4` | Projects one vector onto another. |
 | [ReflectResolver](reflect-resolver.md) | `Vector2`/`Vector3` | Reflects a vector off a surface defined by a normal vector. |
 | [RejectResolver](reject-resolver.md) | `Vector2`/`Vector3`/`Vector4` | Rejects one vector from another. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -74,7 +74,7 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [DegToRadResolver](degtorad-resolver.md) | `float`/`double`/`Vector2`/`Vector3`/`Vector4` | Converts degrees to radians. |
 | [DivideResolver](divide-resolver.md) | *(promoted or same vector type)* | Divides two numeric values, vectors component-wise, or two quaternions. |
 | [FloorResolver](floor-resolver.md) | *(same)* | Rounds down to the largest integer less than or equal to the operand. |
-| [LerpResolver](lerp-resolver.md) | `float`/`double`/`vector2`/`vector3`/`vector4`/`quaternion` | Linearly interpolates between two values (scalar, vector, or quaternion). |
+| [LerpResolver](lerp-resolver.md) | `float`/`double`/`Vector2`/`Vector3`/`Vector4`/`Quaternion` | Linearly interpolates between two values (scalar, vector, or quaternion). |
 | [MaxResolver](max-resolver.md) | *(promoted or same vector type)* | Returns the larger of two numeric values or the component-wise maximum of two vectors. |
 | [MinResolver](min-resolver.md) | *(promoted or same vector type)* | Returns the smaller of two numeric values or the component-wise minimum of two vectors. |
 | [ModuloResolver](modulo-resolver.md) | *(promoted)* | Computes the remainder of dividing two numeric values. |
@@ -83,7 +83,7 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [PowResolver](pow-resolver.md) | `float`/`double`/`Vector2`/`Vector3`/`Vector4` | Raises a value to a specified power. |
 | [RadToDegResolver](radtodeg-resolver.md) | `float`/`double`/`Vector2`/`Vector3`/`Vector4` | Converts radians to degrees. |
 | [RoundResolver](round-resolver.md) | *(same)* | Rounds to a specified number of digits with configurable rounding mode. |
-| [SqrtResolver](sqrt-resolver.md) | `float`/`double`/`vector2`/`vector3`/`vector4` | Computes the square root of a numeric value or component-wise square root of a vector. |
+| [SqrtResolver](sqrt-resolver.md) | `float`/`double`/`Vector2`/`Vector3`/`Vector4` | Computes the square root of a numeric value or component-wise square root of a vector. |
 | [SubtractResolver](subtract-resolver.md) | *(promoted or same vector type)* | Subtracts two numeric, vector or quaternion values. |
 | [TruncateResolver](truncate-resolver.md) | *(same)* | Removes the fractional part, rounding toward zero. |
 
@@ -103,7 +103,7 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [DotResolver](dot-resolver.md) | `float` | Computes the dot product of two vectors or two quaternions. |
 | [LengthResolver](length-resolver.md) | `float` | Computes the length (magnitude) of a vector or quaternion operand. |
 | [LengthSquaredResolver](lengthsquared-resolver.md) | `float` | Computes the squared length of a vector or quaternion operand. |
-| [NormalizeResolver](normalize-resolver.md) | `vector2`/`vector3`/`vector4`/`plane`/`quaternion` | Computes the normalized form of a vector, plane, or quaternion. |
+| [NormalizeResolver](normalize-resolver.md) | `Vector2`/`Vector3`/`Vector4`/`Plane`/`Quaternion` | Computes the normalized form of a vector, plane, or quaternion. |
 | [ProjectResolver](project-resolver.md) | `Vector2`/`Vector3`/`Vector4` | Projects one vector onto another. |
 | [ReflectResolver](reflect-resolver.md) | `Vector2`/`Vector3` | Reflects a vector off a surface defined by a normal vector. |
 | [RejectResolver](reject-resolver.md) | `Vector2`/`Vector3`/`Vector4` | Rejects one vector from another. |

--- a/docs/statescript/resolvers/degtorad-resolver.md
+++ b/docs/statescript/resolvers/degtorad-resolver.md
@@ -1,9 +1,9 @@
 # DegToRadResolver
 
 > **Type:** `Gamesmiths.Forge.Statescript.Properties.DegToRadResolver`
-> **Output Type:** `float` or `double`
+> **Output Type:** `float`, `double`, `Vector2`, `Vector3`, or `Vector4`
 
-Converts an angle from degrees to radians. Computes `degrees * (π / 180)`. Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+Converts an angle from degrees to radians. Computes `degrees * (π / 180)`. Supports `float` and `double` types, as well as `Vector2`, `Vector3`, and `Vector4` for component-wise conversion. Integer operand types are promoted to `double`. Decimal and quaternion types are not supported.
 
 ## Constructor
 
@@ -22,16 +22,20 @@ new DegToRadResolver(operand)
 | `float` | `float` |
 | `double` | `double` |
 | Any integer type | `double` |
+| `Vector2` | `Vector2` |
+| `Vector3` | `Vector3` |
+| `Vector4` | `Vector4` |
 
 **Invalid types** (throw `ArgumentException` at construction time):
 - `decimal` (use `double` instead).
-- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- `Quaternion`.
 - Unsupported types (`bool`, `char`).
 
 ## Behavior
 
 - Resolves the operand through its `IPropertyResolver` instance.
 - Multiplies the value by `π / 180` and returns the result as a `Variant128`.
+- For vector types, conversion is applied component-wise.
 - `DegToRad(0) = 0`, `DegToRad(90) = π/2`, `DegToRad(180) = π`, `DegToRad(360) = 2π`.
 - Type validation happens at construction time (fail-fast), not at runtime.
 
@@ -56,6 +60,10 @@ graph.VariableDefinitions.DefineProperty("headingRotation",
             new VariableResolver("pitchDegrees", typeof(float))),
         new DegToRadResolver(
             new VariableResolver("rollDegrees", typeof(float)))));
+
+graph.VariableDefinitions.DefineProperty("eulerRadians",
+    new DegToRadResolver(
+        new VariableResolver("eulerDegrees", typeof(Vector3))));
 ```
 
 ## See Also

--- a/docs/statescript/resolvers/pow-resolver.md
+++ b/docs/statescript/resolvers/pow-resolver.md
@@ -1,9 +1,9 @@
 # PowResolver
 
 > **Type:** `Gamesmiths.Forge.Statescript.Properties.PowResolver`
-> **Output Type:** `float` or `double`
+> **Output Type:** `float`, `double`, `Vector2`, `Vector3`, or `Vector4`
 
-Raises a base value to a specified exponent. Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+Raises a base value to a specified exponent. Supports `float` and `double` types, as well as `Vector2`, `Vector3`, and `Vector4` for component-wise exponentiation. Integer operand types are promoted to `double`. Decimal and quaternion types are not supported. Vector operands must be the same type.
 
 ## Constructor
 
@@ -23,16 +23,20 @@ new PowResolver(baseOperand, exponent)
 | Both `float` | `float` |
 | Any `double` | `double` |
 | Any integer type | `double` |
+| `Vector2`, `Vector2` | `Vector2` |
+| `Vector3`, `Vector3` | `Vector3` |
+| `Vector4`, `Vector4` | `Vector4` |
 
 **Invalid types** (throw `ArgumentException` at construction time):
 - `decimal` (use `double` instead).
-- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- Mixed vector types, scalar/vector mixes, and `Quaternion`.
 - Unsupported types (`bool`, `char`).
 
 ## Behavior
 
 - Resolves both operands through their respective `IPropertyResolver` instances.
-- Computes `Math.Pow(base, exponent)` (or `MathF.Pow` for `float`) and returns the result as a `Variant128`.
+- Computes `Math.Pow(base, exponent)` (or `MathF.Pow` for `float`) for scalar types.
+- For vector types, computes the power component-wise using `MathF.Pow` for each corresponding component.
 - Any exponent of `0` returns `1`.
 - Any exponent of `1` returns the base value.
 - Fractional exponents compute roots (e.g., `Pow(4, 0.5) = 2`).
@@ -53,14 +57,11 @@ graph.VariableDefinitions.DefineProperty("scaledDamage",
 ## Composition
 
 ```csharp
-// Experience curve: xpRequired = baseXP * Pow(level, growthExponent)
+// Weight each distance component independently before summing
 graph.VariableDefinitions.DefineProperty("xpRequired",
-    new FloorResolver(
-        new MultiplyResolver(
-            new VariableResolver("baseXP", typeof(double)),
-            new PowResolver(
-                new VariableResolver("level", typeof(double)),
-                new VariableResolver("growthExponent", typeof(double))))));
+    new PowResolver(
+        new VariableResolver("distanceByAxis", typeof(Vector3)),
+        new VariantResolver(new Variant128(new Vector3(2.0f, 2.0f, 1.0f)), typeof(Vector3))));
 ```
 
 ## See Also

--- a/docs/statescript/resolvers/pow-resolver.md
+++ b/docs/statescript/resolvers/pow-resolver.md
@@ -3,7 +3,7 @@
 > **Type:** `Gamesmiths.Forge.Statescript.Properties.PowResolver`
 > **Output Type:** `float`, `double`, `Vector2`, `Vector3`, or `Vector4`
 
-Raises a base value to a specified exponent. Supports `float` and `double` types, as well as `Vector2`, `Vector3`, and `Vector4` for component-wise exponentiation. Integer operand types are promoted to `double`. Decimal and quaternion types are not supported. Vector operands must be the same type.
+Raises a base value to a specified exponent. Supports `float` and `double` types, as well as `Vector2`, `Vector3`, and `Vector4` for component-wise exponentiation. Integer operand types are promoted to `double`. For vector bases, the exponent must be a scalar numeric value applied uniformly to all components. Decimal and quaternion types are not supported.
 
 ## Constructor
 
@@ -23,20 +23,23 @@ new PowResolver(baseOperand, exponent)
 | Both `float` | `float` |
 | Any `double` | `double` |
 | Any integer type | `double` |
-| `Vector2`, `Vector2` | `Vector2` |
-| `Vector3`, `Vector3` | `Vector3` |
-| `Vector4`, `Vector4` | `Vector4` |
+| `Vector2`, scalar numeric | `Vector2` |
+| `Vector3`, scalar numeric | `Vector3` |
+| `Vector4`, scalar numeric | `Vector4` |
 
 **Invalid types** (throw `ArgumentException` at construction time):
 - `decimal` (use `double` instead).
-- Mixed vector types, scalar/vector mixes, and `Quaternion`.
+- `Quaternion` (not supported).
+- Any vector type as exponent (e.g., `Vector2`/`Vector3`).
+- Any scalar/vector mix where the exponent is a vector (e.g., `float`/`Vector2`).
+- Unsupported non-numeric exponent types for vectors.
 - Unsupported types (`bool`, `char`).
 
 ## Behavior
 
 - Resolves both operands through their respective `IPropertyResolver` instances.
 - Computes `Math.Pow(base, exponent)` (or `MathF.Pow` for `float`) for scalar types.
-- For vector types, computes the power component-wise using `MathF.Pow` for each corresponding component.
+- For vector types, computes the power component-wise using `MathF.Pow` with one shared scalar exponent applied to each component.
 - Any exponent of `0` returns `1`.
 - Any exponent of `1` returns the base value.
 - Fractional exponents compute roots (e.g., `Pow(4, 0.5) = 2`).
@@ -57,11 +60,11 @@ graph.VariableDefinitions.DefineProperty("scaledDamage",
 ## Composition
 
 ```csharp
-// Weight each distance component independently before summing
-graph.VariableDefinitions.DefineProperty("xpRequired",
+// Apply component-wise exponentiation to scale each distance axis independently
+graph.VariableDefinitions.DefineProperty("scaledDistances",
     new PowResolver(
         new VariableResolver("distanceByAxis", typeof(Vector3)),
-        new VariantResolver(new Variant128(new Vector3(2.0f, 2.0f, 1.0f)), typeof(Vector3))));
+        new VariantResolver(new Variant128(2.0f), typeof(float))));
 ```
 
 ## See Also

--- a/docs/statescript/resolvers/radtodeg-resolver.md
+++ b/docs/statescript/resolvers/radtodeg-resolver.md
@@ -1,9 +1,9 @@
 # RadToDegResolver
 
 > **Type:** `Gamesmiths.Forge.Statescript.Properties.RadToDegResolver`
-> **Output Type:** `float` or `double`
+> **Output Type:** `float`, `double`, `Vector2`, `Vector3`, or `Vector4`
 
-Converts an angle from radians to degrees. Computes `radians * (180 / π)`. Supports `float` and `double` types. Integer operand types are promoted to `double`. Decimal, vector, and quaternion types are not supported.
+Converts an angle from radians to degrees. Computes `radians * (180 / π)`. Supports `float` and `double` types, as well as `Vector2`, `Vector3`, and `Vector4` for component-wise conversion. Integer operand types are promoted to `double`. Decimal and quaternion types are not supported.
 
 ## Constructor
 
@@ -22,16 +22,20 @@ new RadToDegResolver(operand)
 | `float` | `float` |
 | `double` | `double` |
 | Any integer type | `double` |
+| `Vector2` | `Vector2` |
+| `Vector3` | `Vector3` |
+| `Vector4` | `Vector4` |
 
 **Invalid types** (throw `ArgumentException` at construction time):
 - `decimal` (use `double` instead).
-- `Vector2`, `Vector3`, `Vector4`, `Quaternion`.
+- `Quaternion`.
 - Unsupported types (`bool`, `char`).
 
 ## Behavior
 
 - Resolves the operand through its `IPropertyResolver` instance.
 - Multiplies the value by `180 / π` and returns the result as a `Variant128`.
+- For vector types, conversion is applied component-wise.
 - `RadToDeg(0) = 0`, `RadToDeg(π/2) = 90`, `RadToDeg(π) = 180`, `RadToDeg(2π) = 360`.
 - `RadToDeg` and `DegToRad` are inverses: `RadToDeg(DegToRad(x)) = x`.
 - Type validation happens at construction time (fail-fast), not at runtime.
@@ -56,6 +60,10 @@ graph.VariableDefinitions.DefineProperty("yawDegrees",
             new VariantResolver(new Variant128(Vector3.UnitZ), typeof(Vector3)),
             new VariableResolver("targetDirection", typeof(Vector3)),
             new VariantResolver(new Variant128(Vector3.UnitY), typeof(Vector3)))));
+
+graph.VariableDefinitions.DefineProperty("eulerDegrees",
+    new RadToDegResolver(
+        new VariableResolver("eulerRadians", typeof(Vector3))));
 ```
 
 ## See Also


### PR DESCRIPTION
## Changed
- DegToRad, RadToDeg and Pow resolvers can now be used with Vector types.