### PR TITLE
Added support for reference type resolvers.

### DIFF
--- a/Forge.Tests/Helpers/StatescriptTestHelpers.cs
+++ b/Forge.Tests/Helpers/StatescriptTestHelpers.cs
@@ -54,6 +54,15 @@ internal static class ResolverTestContextFactory
 {
 	public static GraphContext CreateAbilityGraphContext(TestEntity entity, float magnitude = 0f)
 	{
+		return CreateAbilityGraphContext(entity, target: null, source: null, magnitude: magnitude);
+	}
+
+	public static GraphContext CreateAbilityGraphContext(
+		TestEntity owner,
+		TestEntity? target,
+		TestEntity? source,
+		float magnitude = 0f)
+	{
 		var graph = new Graph();
 		var captureNode = new CaptureGraphContextNode();
 
@@ -65,10 +74,11 @@ internal static class ResolverTestContextFactory
 		var behavior = new GraphAbilityBehavior(graph);
 
 		AbilityData abilityData = CreateAbilityData("ResolverTest", () => behavior);
-		AbilityHandle? handle = Grant(entity, abilityData) ?? throw new InvalidOperationException(
+		AbilityHandle handle = Grant(owner, abilityData, source)
+			?? throw new InvalidOperationException(
 				"Failed to grant the resolver test ability and create an ability graph context.");
 
-		if (!handle.Activate(out _, magnitude: magnitude))
+		if (!handle.Activate(out _, target, magnitude))
 		{
 			throw new InvalidOperationException(
 				"Failed to activate the resolver test ability while creating an ability graph context." +
@@ -117,7 +127,37 @@ internal static class ResolverTestContextFactory
 		return captureNode.CapturedGraphContext;
 	}
 
+	public static void ExecuteAbilityGraph(
+		TestEntity owner,
+		ActionNode actionNode,
+		TestEntity? target = null,
+		TestEntity? source = null,
+		float magnitude = 0f)
+	{
+		var graph = new Graph();
+
+		graph.AddNode(actionNode);
+		graph.AddConnection(new Connection(
+			graph.EntryNode.OutputPorts[EntryNode.OutputPort],
+			actionNode.InputPorts[ActionNode.InputPort]));
+
+		var behavior = new GraphAbilityBehavior(graph);
+		AbilityData abilityData = CreateAbilityData("ResolverExecutionTest", () => behavior);
+		AbilityHandle handle = Grant(owner, abilityData, source)
+			?? throw new InvalidOperationException("Failed to grant the resolver execution test ability.");
+
+		if (!handle.Activate(out _, target, magnitude))
+		{
+			throw new InvalidOperationException("Failed to activate the resolver execution test ability.");
+		}
+	}
+
 	private static AbilityHandle? Grant(TestEntity target, AbilityData data)
+	{
+		return Grant(target, data, sourceEntity: null);
+	}
+
+	private static AbilityHandle? Grant(TestEntity target, AbilityData data, IForgeEntity? sourceEntity)
 	{
 		var grantConfig = new GrantAbilityConfig(
 			data,
@@ -128,15 +168,10 @@ internal static class ResolverTestContextFactory
 			false,
 			LevelComparison.Higher);
 
-		var effectData = new EffectData(
-			"Grant",
-			new DurationData(DurationType.Infinite),
-			effectComponents: [new GrantAbilityEffectComponent([grantConfig])]);
-
-		var grantEffect = new Effect(effectData, new EffectOwnership(null, null));
+		Effect grantEffect = CreateGrantEffect("Grant", grantConfig, sourceEntity);
 		_ = target.EffectsManager.ApplyEffect(grantEffect);
 
-		target.Abilities.TryGetAbility(data, out AbilityHandle? handle);
+		target.Abilities.TryGetAbility(data, out AbilityHandle? handle, sourceEntity);
 
 		if (handle is null)
 		{
@@ -145,6 +180,16 @@ internal static class ResolverTestContextFactory
 		}
 
 		return handle;
+	}
+
+	private static Effect CreateGrantEffect(string name, GrantAbilityConfig config, IForgeEntity? sourceEntity)
+	{
+		var effectData = new EffectData(
+			name,
+			new DurationData(DurationType.Infinite),
+			effectComponents: [new GrantAbilityEffectComponent([config])]);
+
+		return new Effect(effectData, new EffectOwnership(null, sourceEntity));
 	}
 
 	private static AbilityData CreateAbilityData(string name, Func<IAbilityBehavior> behaviorFactory)
@@ -309,6 +354,65 @@ internal sealed class ReadArrayPropertyNode : ActionNode
 		}
 
 		LastReadArray = resolved;
+	}
+}
+
+internal sealed class ReadReferencePropertyNode<T> : ActionNode
+	where T : class
+{
+	public T? LastReadValue { get; private set; }
+
+	protected override void DefineParameters(List<InputProperty> inputProperties, List<OutputVariable> outputVariables)
+	{
+		inputProperties.Add(new InputProperty("Value", typeof(T)));
+	}
+
+	protected override void Execute(GraphContext graphContext)
+	{
+		graphContext.TryResolveReference(InputProperties[0].BoundName, out T? value);
+		LastReadValue = value;
+	}
+}
+
+internal sealed class ReadReferenceArrayPropertyNode<T> : ActionNode
+	where T : class
+{
+	public T?[]? LastReadArray { get; private set; }
+
+	protected override void DefineParameters(List<InputProperty> inputProperties, List<OutputVariable> outputVariables)
+	{
+		inputProperties.Add(new InputProperty("Array", typeof(T[])));
+	}
+
+	protected override void Execute(GraphContext graphContext)
+	{
+		graphContext.TryResolveReferenceArray(InputProperties[0].BoundName, out T?[]? values);
+		LastReadArray = values;
+	}
+}
+
+internal sealed class ResolvePropertyNode(IPropertyResolver resolver) : ActionNode
+{
+	private readonly IPropertyResolver _resolver = resolver;
+
+	public Variant128 LastResolvedValue { get; private set; }
+
+	protected override void Execute(GraphContext graphContext)
+	{
+		LastResolvedValue = _resolver.Resolve(graphContext);
+	}
+}
+
+internal sealed class ResolveReferenceResolverNode<T>(IReferenceResolver<T> resolver) : ActionNode
+	where T : class
+{
+	private readonly IReferenceResolver<T> _resolver = resolver;
+
+	public T? LastResolvedValue { get; private set; }
+
+	protected override void Execute(GraphContext graphContext)
+	{
+		LastResolvedValue = _resolver.Resolve(graphContext);
 	}
 }
 

--- a/Forge.Tests/Statescript/ReferenceValueSupportTests.cs
+++ b/Forge.Tests/Statescript/ReferenceValueSupportTests.cs
@@ -1,0 +1,87 @@
+// Copyright © Gamesmiths Guild.
+
+using FluentAssertions;
+using Gamesmiths.Forge.Core;
+using Gamesmiths.Forge.Cues;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Nodes;
+using Gamesmiths.Forge.Statescript.Properties;
+using Gamesmiths.Forge.Tags;
+using Gamesmiths.Forge.Tests.Helpers;
+
+namespace Gamesmiths.Forge.Tests.Statescript;
+
+public class ReferenceValueSupportTests(TagsAndCuesFixture tagsAndCuesFixture) : IClassFixture<TagsAndCuesFixture>
+{
+	private readonly TagsManager _tagsManager = tagsAndCuesFixture.TagsManager;
+	private readonly CuesManager _cuesManager = tagsAndCuesFixture.CuesManager;
+
+	[Fact]
+	[Trait("Statescript", "ReferenceValues")]
+	public void Variables_initialize_reference_variables_and_arrays_from_definitions()
+	{
+		var entity1 = new TestEntity(_tagsManager, _cuesManager);
+		var entity2 = new TestEntity(_tagsManager, _cuesManager);
+		var definitions = new GraphVariableDefinitions();
+
+		definitions.DefineReferenceVariable<IForgeEntity>("selected", entity1);
+		definitions.DefineReferenceArrayVariable<IForgeEntity>("entities", entity1, entity2);
+
+		var variables = new Variables();
+		variables.InitializeFrom(definitions);
+
+		variables.TryGetReference("selected", out IForgeEntity? selected).Should().BeTrue();
+		selected.Should().BeSameAs(entity1);
+
+		variables.TryGetReferenceArray("entities", out IForgeEntity?[]? entities).Should().BeTrue();
+		entities.Should().Equal(entity1, entity2);
+	}
+
+	[Fact]
+	[Trait("Statescript", "ReferenceValues")]
+	public void Graph_context_resolves_reference_properties_and_arrays()
+	{
+		var entity1 = new TestEntity(_tagsManager, _cuesManager);
+		var entity2 = new TestEntity(_tagsManager, _cuesManager);
+		var graph = new Graph();
+		var readSelectedEntity = new ReadReferencePropertyNode<IForgeEntity>();
+		var readEntityGroup = new ReadReferenceArrayPropertyNode<IForgeEntity>();
+
+		graph.VariableDefinitions.DefineReferenceVariable<IForgeEntity>("selected");
+		graph.VariableDefinitions.DefineReferenceArrayVariable<IForgeEntity>("entities", entity1, entity2);
+		graph.VariableDefinitions.DefineReferenceProperty("selectedEntity", new EntityVariableResolver("selected"));
+		graph.VariableDefinitions.DefineReferenceArrayProperty(
+			"entityGroup",
+			new ReferenceArrayVariableResolver<IForgeEntity>("entities"));
+		readSelectedEntity.BindInput(0, "selectedEntity");
+		readEntityGroup.BindInput(0, "entityGroup");
+		graph.AddNode(readSelectedEntity);
+		graph.AddNode(readEntityGroup);
+		graph.AddConnection(new Connection(
+			graph.EntryNode.OutputPorts[EntryNode.OutputPort],
+			readSelectedEntity.InputPorts[ActionNode.InputPort]));
+		graph.AddConnection(new Connection(
+			readSelectedEntity.OutputPorts[ActionNode.OutputPort],
+			readEntityGroup.InputPorts[ActionNode.InputPort]));
+
+		var processor = new GraphProcessor(graph);
+		processor.StartGraph(variables => variables.SetReference("selected", entity2));
+
+		readSelectedEntity.LastReadValue.Should().BeSameAs(entity2);
+		readEntityGroup.LastReadArray.Should().Equal(entity1, entity2);
+	}
+
+	[Fact]
+	[Trait("Statescript", "ReferenceValues")]
+	public void Graph_variable_definitions_validate_reference_types()
+	{
+		var graph = new Graph();
+
+		graph.VariableDefinitions.DefineReferenceProperty("owner", new OwnerEntityResolver());
+		graph.VariableDefinitions.DefineReferenceArrayVariable<IForgeEntity>("entities");
+
+		graph.VariableDefinitions.ValidatePropertyType("owner", typeof(IForgeEntity)).Should().BeTrue();
+		graph.VariableDefinitions.ValidatePropertyType("entities", typeof(IForgeEntity[])).Should().BeTrue();
+		graph.VariableDefinitions.ValidatePropertyType("owner", typeof(string)).Should().BeFalse();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/AttributeResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/AttributeResolverTests.cs
@@ -61,6 +61,42 @@ public class AttributeResolverTests(TagsAndCuesFixture tagsAndCuesFixture) : ICl
 
 	[Fact]
 	[Trait("Resolver", "Attribute")]
+	public void Attribute_resolver_can_read_from_entity_variable_without_activation_context()
+	{
+		var selectedEntity = new TestEntity(_tagsManager, _cuesManager);
+		var context = new GraphContext();
+		var resolver = new AttributeResolver(
+			"TestAttributeSet.Attribute5",
+			new EntityVariableResolver("selectedEntity"));
+
+		ApplyFlatModifier(selectedEntity, "TestAttributeSet.Attribute5", 10);
+		context.GraphVariables.DefineReferenceVariable<IForgeEntity>("selectedEntity", selectedEntity);
+
+		Variant128 result = resolver.Resolve(context);
+
+		result.AsInt().Should().Be(15);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Attribute")]
+	public void Attribute_resolver_can_read_from_target_entity()
+	{
+		var owner = new TestEntity(_tagsManager, _cuesManager);
+		var target = new TestEntity(_tagsManager, _cuesManager);
+		var node = new ResolvePropertyNode(
+			new AttributeResolver(
+				"TestAttributeSet.Attribute5",
+				new TargetEntityResolver()));
+
+		ApplyFlatModifier(target, "TestAttributeSet.Attribute5", 10);
+
+		ExecuteAbilityGraph(owner, node, target, source: null);
+
+		node.LastResolvedValue.AsInt().Should().Be(15);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Attribute")]
 	public void Attribute_resolver_reads_magnitude_evaluated_up_to_channel()
 	{
 		var entity = new TestEntity(_tagsManager, _cuesManager);

--- a/Forge.Tests/Statescript/Resolvers/EntityArrayVariableResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/EntityArrayVariableResolverTests.cs
@@ -1,0 +1,59 @@
+// Copyright © Gamesmiths Guild.
+
+using FluentAssertions;
+using Gamesmiths.Forge.Core;
+using Gamesmiths.Forge.Cues;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+using Gamesmiths.Forge.Tags;
+using Gamesmiths.Forge.Tests.Helpers;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class EntityArrayVariableResolverTests(TagsAndCuesFixture tagsAndCuesFixture) : IClassFixture<TagsAndCuesFixture>
+{
+	private readonly TagsManager _tagsManager = tagsAndCuesFixture.TagsManager;
+	private readonly CuesManager _cuesManager = tagsAndCuesFixture.CuesManager;
+
+	[Fact]
+	[Trait("Resolver", "EntityArrayVariable")]
+	public void Entity_array_variable_resolver_reads_graph_reference_array()
+	{
+		var entity1 = new TestEntity(_tagsManager, _cuesManager);
+		var entity2 = new TestEntity(_tagsManager, _cuesManager);
+		var context = new GraphContext();
+		var resolver = new EntityArrayVariableResolver("targets");
+
+		context.GraphVariables.DefineReferenceArrayVariable<IForgeEntity>("targets", [entity1, entity2]);
+
+		IForgeEntity?[] result = resolver.ResolveArray(context);
+
+		result.Should().Equal(entity1, entity2);
+	}
+
+	[Fact]
+	[Trait("Resolver", "EntityArrayVariable")]
+	public void Entity_array_variable_resolver_reads_shared_reference_array()
+	{
+		var entity1 = new TestEntity(_tagsManager, _cuesManager);
+		var entity2 = new TestEntity(_tagsManager, _cuesManager);
+		var sharedVariables = new Variables();
+		var context = new GraphContext { SharedVariables = sharedVariables };
+		var resolver = new EntityArrayVariableResolver("targets", VariableScope.Shared);
+
+		sharedVariables.DefineReferenceArrayVariable<IForgeEntity>("targets", [entity1, entity2]);
+
+		IForgeEntity?[] result = resolver.ResolveArray(context);
+
+		result.Should().Equal(entity1, entity2);
+	}
+
+	[Fact]
+	[Trait("Resolver", "EntityArrayVariable")]
+	public void Entity_array_variable_resolver_returns_empty_array_for_missing_variable()
+	{
+		var resolver = new EntityArrayVariableResolver("missing");
+
+		resolver.ResolveArray(new GraphContext()).Should().BeEmpty();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/EntityResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/EntityResolverTests.cs
@@ -1,0 +1,64 @@
+// Copyright © Gamesmiths Guild.
+
+using FluentAssertions;
+using Gamesmiths.Forge.Core;
+using Gamesmiths.Forge.Cues;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+using Gamesmiths.Forge.Tags;
+using Gamesmiths.Forge.Tests.Helpers;
+
+using static Gamesmiths.Forge.Tests.Helpers.ResolverTestContextFactory;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class EntityResolverTests(TagsAndCuesFixture tagsAndCuesFixture) : IClassFixture<TagsAndCuesFixture>
+{
+	private readonly TagsManager _tagsManager = tagsAndCuesFixture.TagsManager;
+	private readonly CuesManager _cuesManager = tagsAndCuesFixture.CuesManager;
+
+	[Fact]
+	[Trait("Resolver", "Entity")]
+	public void Owner_entity_resolver_reads_owner_entity()
+	{
+		var owner = new TestEntity(_tagsManager, _cuesManager);
+		GraphContext context = CreateAbilityGraphContext(owner);
+
+		new OwnerEntityResolver().Resolve(context).Should().BeSameAs(owner);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Entity")]
+	public void Source_entity_resolver_reads_source_entity()
+	{
+		var owner = new TestEntity(_tagsManager, _cuesManager);
+		var source = new TestEntity(_tagsManager, _cuesManager);
+		GraphContext context = CreateAbilityGraphContext(owner, target: null, source: source);
+
+		new SourceEntityResolver().Resolve(context).Should().BeSameAs(source);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Entity")]
+	public void Target_entity_resolver_reads_target_entity()
+	{
+		var owner = new TestEntity(_tagsManager, _cuesManager);
+		var target = new TestEntity(_tagsManager, _cuesManager);
+		var node = new ResolveReferenceResolverNode<IForgeEntity>(new TargetEntityResolver());
+
+		ExecuteAbilityGraph(owner, node, target, source: null);
+
+		node.LastResolvedValue.Should().BeSameAs(target);
+	}
+
+	[Fact]
+	[Trait("Resolver", "Entity")]
+	public void Entity_resolvers_return_null_without_activation_context()
+	{
+		var context = new GraphContext();
+
+		new OwnerEntityResolver().Resolve(context).Should().BeNull();
+		new SourceEntityResolver().Resolve(context).Should().BeNull();
+		new TargetEntityResolver().Resolve(context).Should().BeNull();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/ReferenceVariableResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/ReferenceVariableResolverTests.cs
@@ -1,0 +1,53 @@
+// Copyright © Gamesmiths Guild.
+
+using FluentAssertions;
+using Gamesmiths.Forge.Core;
+using Gamesmiths.Forge.Cues;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+using Gamesmiths.Forge.Tags;
+using Gamesmiths.Forge.Tests.Helpers;
+
+namespace Gamesmiths.Forge.Tests.Statescript.Resolvers;
+
+public class ReferenceVariableResolverTests(TagsAndCuesFixture tagsAndCuesFixture) : IClassFixture<TagsAndCuesFixture>
+{
+	private readonly TagsManager _tagsManager = tagsAndCuesFixture.TagsManager;
+	private readonly CuesManager _cuesManager = tagsAndCuesFixture.CuesManager;
+
+	[Fact]
+	[Trait("Resolver", "ReferenceVariable")]
+	public void Reference_variable_resolver_reads_graph_reference_variable()
+	{
+		var entity = new TestEntity(_tagsManager, _cuesManager);
+		var resolver = new ReferenceVariableResolver<IForgeEntity>("selectedEntity");
+		var context = new GraphContext();
+
+		context.GraphVariables.DefineReferenceVariable<IForgeEntity>("selectedEntity", entity);
+
+		resolver.Resolve(context).Should().BeSameAs(entity);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ReferenceVariable")]
+	public void Reference_variable_resolver_reads_shared_reference_variable()
+	{
+		var entity = new TestEntity(_tagsManager, _cuesManager);
+		var sharedVariables = new Variables();
+		var resolver = new ReferenceVariableResolver<IForgeEntity>("selectedEntity", VariableScope.Shared);
+		var context = new GraphContext { SharedVariables = sharedVariables };
+
+		sharedVariables.DefineReferenceVariable<IForgeEntity>("selectedEntity", entity);
+
+		resolver.Resolve(context).Should().BeSameAs(entity);
+	}
+
+	[Fact]
+	[Trait("Resolver", "ReferenceVariable")]
+	public void Reference_variable_resolver_returns_null_for_missing_variable()
+	{
+		var resolver = new ReferenceVariableResolver<IForgeEntity>("missing");
+
+		resolver.Resolve(new GraphContext()).Should().BeNull();
+	}
+}

--- a/Forge.Tests/Statescript/Resolvers/TagQueryResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/TagQueryResolverTests.cs
@@ -1,6 +1,7 @@
 // Copyright © Gamesmiths Guild.
 
 using FluentAssertions;
+using Gamesmiths.Forge.Core;
 using Gamesmiths.Forge.Cues;
 using Gamesmiths.Forge.Effects;
 using Gamesmiths.Forge.Effects.Components;
@@ -169,6 +170,44 @@ public class TagQueryResolverTests(TagsAndCuesFixture tagsAndCuesFixture) : ICla
 		Variant128 result = resolver.Resolve(context);
 
 		result.AsBool().Should().BeTrue();
+	}
+
+	[Fact]
+	[Trait("Resolver", "TagQuery")]
+	public void Tag_query_resolver_can_read_selected_entity_from_variable_without_activation_context()
+	{
+		var entity = new TestEntity(_tagsManager, _cuesManager);
+		var context = new GraphContext();
+		var resolver = new TagQueryResolver(
+			Tag.RequestTag(_tagsManager, "item.equipment.weapon.axe"),
+			new EntityVariableResolver("selectedEntity"),
+			TagQuerySource.ModifierTags);
+
+		ApplyModifierTags(entity, "item.equipment.weapon.axe");
+		context.GraphVariables.DefineReferenceVariable<IForgeEntity>("selectedEntity", entity);
+
+		Variant128 result = resolver.Resolve(context);
+
+		result.AsBool().Should().BeTrue();
+	}
+
+	[Fact]
+	[Trait("Resolver", "TagQuery")]
+	public void Tag_query_resolver_can_read_target_entity()
+	{
+		var owner = new TestEntity(_tagsManager, _cuesManager);
+		var target = new TestEntity(_tagsManager, _cuesManager);
+		var node = new ResolvePropertyNode(
+			new TagQueryResolver(
+				Tag.RequestTag(_tagsManager, "item.equipment.weapon.axe"),
+				new TargetEntityResolver(),
+				TagQuerySource.ModifierTags));
+
+		ApplyModifierTags(target, "item.equipment.weapon.axe");
+
+		ExecuteAbilityGraph(owner, node, target, source: null);
+
+		node.LastResolvedValue.AsBool().Should().BeTrue();
 	}
 
 	[Fact]

--- a/Forge/Statescript/GraphContext.cs
+++ b/Forge/Statescript/GraphContext.cs
@@ -183,6 +183,94 @@ public sealed class GraphContext
 	}
 
 	/// <summary>
+	/// Resolves a named reference value by first checking reference variables and then falling back to read-only
+	/// reference property definitions on the graph.
+	/// </summary>
+	/// <typeparam name="T">The reference type to interpret the value as.</typeparam>
+	/// <param name="name">The name of the variable or property.</param>
+	/// <param name="value">The resolved value if found.</param>
+	/// <returns><see langword="true"/> if the name was resolved and type-compatible; <see langword="false"/> otherwise.
+	/// </returns>
+	public bool TryResolveReference<T>(StringKey name, out T? value)
+		where T : class
+	{
+		if (GraphVariables.TryGetReference(name, out value))
+		{
+			return true;
+		}
+
+		if (Processor is null)
+		{
+			value = null;
+			return false;
+		}
+
+		foreach (ReferencePropertyDefinition definition in Processor.Graph.VariableDefinitions.ReferencePropertyDefinitions)
+		{
+			if (definition.Name == name)
+			{
+				if (!typeof(T).IsAssignableFrom(definition.Resolver.ValueType))
+				{
+					value = null;
+					return false;
+				}
+
+				value = (T?)definition.Resolver.Resolve(this);
+				return true;
+			}
+		}
+
+		value = null;
+		return false;
+	}
+
+	/// <summary>
+	/// Resolves a named reference array by first checking reference array variables and then falling back to read-only
+	/// reference array property definitions on the graph.
+	/// </summary>
+	/// <typeparam name="T">The element type to interpret the array as.</typeparam>
+	/// <param name="name">The name of the array variable or property.</param>
+	/// <param name="values">The resolved array if found.</param>
+	/// <returns><see langword="true"/> if the name was resolved and type-compatible; <see langword="false"/> otherwise.
+	/// </returns>
+	public bool TryResolveReferenceArray<T>(StringKey name, out T?[]? values)
+		where T : class
+	{
+		if (GraphVariables.TryGetReferenceArray(name, out values))
+		{
+			return true;
+		}
+
+		if (Processor is not null)
+		{
+			foreach (ReferenceArrayPropertyDefinition definition in
+				Processor.Graph.VariableDefinitions.ReferenceArrayPropertyDefinitions)
+			{
+				if (definition.Name == name)
+				{
+					if (!typeof(T).IsAssignableFrom(definition.Resolver.ElementType))
+					{
+						values = null;
+						return false;
+					}
+
+					object?[] resolved = definition.Resolver.ResolveArray(this);
+					values = new T?[resolved.Length];
+					for (int i = 0; i < resolved.Length; i++)
+					{
+						values[i] = (T?)resolved[i];
+					}
+
+					return true;
+				}
+			}
+		}
+
+		values = null;
+		return false;
+	}
+
+	/// <summary>
 	/// Gets the node context of type T for the specified node ID. The context is guaranteed to exist because the
 	/// framework creates it automatically when the node first receives a message, before any user code runs.
 	/// </summary>

--- a/Forge/Statescript/GraphVariableDefinitions.cs
+++ b/Forge/Statescript/GraphVariableDefinitions.cs
@@ -19,9 +19,19 @@ public class GraphVariableDefinitions
 	public List<VariableDefinition> VariableDefinitions { get; } = [];
 
 	/// <summary>
+	/// Gets the list of reference variable definitions for the graph.
+	/// </summary>
+	public List<ReferenceVariableDefinition> ReferenceVariableDefinitions { get; } = [];
+
+	/// <summary>
 	/// Gets the list of array variable definitions for the graph.
 	/// </summary>
 	public List<ArrayVariableDefinition> ArrayVariableDefinitions { get; } = [];
+
+	/// <summary>
+	/// Gets the list of reference array variable definitions for the graph.
+	/// </summary>
+	public List<ReferenceArrayVariableDefinition> ReferenceArrayVariableDefinitions { get; } = [];
 
 	/// <summary>
 	/// Gets the list of property definitions for the graph. Properties are read-only computed values resolved on demand
@@ -30,10 +40,20 @@ public class GraphVariableDefinitions
 	public List<PropertyDefinition> PropertyDefinitions { get; } = [];
 
 	/// <summary>
+	/// Gets the list of reference property definitions for the graph.
+	/// </summary>
+	public List<ReferencePropertyDefinition> ReferencePropertyDefinitions { get; } = [];
+
+	/// <summary>
 	/// Gets the list of array property definitions for the graph. Array properties are read-only computed values that
 	/// resolve to arrays (e.g., a list of entity IDs within a radius).
 	/// </summary>
 	public List<ArrayPropertyDefinition> ArrayPropertyDefinitions { get; } = [];
+
+	/// <summary>
+	/// Gets the list of reference array property definitions for the graph.
+	/// </summary>
+	public List<ReferenceArrayPropertyDefinition> ReferenceArrayPropertyDefinitions { get; } = [];
 
 	/// <summary>
 	/// Adds a mutable variable definition with the specified name and initial value.
@@ -47,6 +67,18 @@ public class GraphVariableDefinitions
 	{
 		Variant128 variant = Variables.CreateVariant(initialValue);
 		VariableDefinitions.Add(new VariableDefinition(name, variant, typeof(T)));
+	}
+
+	/// <summary>
+	/// Adds a mutable reference variable definition with the specified name and initial value.
+	/// </summary>
+	/// <typeparam name="T">The reference type of the initial value.</typeparam>
+	/// <param name="name">The name of the variable.</param>
+	/// <param name="initialValue">The initial value of the variable.</param>
+	public void DefineReferenceVariable<T>(StringKey name, T? initialValue = null)
+		where T : class
+	{
+		ReferenceVariableDefinitions.Add(new ReferenceVariableDefinition(name, initialValue, typeof(T)));
 	}
 
 	/// <summary>
@@ -69,6 +101,19 @@ public class GraphVariableDefinitions
 	}
 
 	/// <summary>
+	/// Adds a mutable reference array variable definition with the specified name and initial values.
+	/// </summary>
+	/// <typeparam name="T">The reference type of each element.</typeparam>
+	/// <param name="name">The name of the array variable.</param>
+	/// <param name="initialValues">The initial values for the array elements.</param>
+	public void DefineReferenceArrayVariable<T>(StringKey name, params T?[] initialValues)
+		where T : class
+	{
+		ReferenceArrayVariableDefinitions.Add(
+			new ReferenceArrayVariableDefinition(name, [.. initialValues.Cast<object?>()], typeof(T)));
+	}
+
+	/// <summary>
 	/// Adds a read-only property definition with the specified name and resolver.
 	/// </summary>
 	/// <param name="name">The name of the property.</param>
@@ -76,6 +121,16 @@ public class GraphVariableDefinitions
 	public void DefineProperty(StringKey name, IPropertyResolver resolver)
 	{
 		PropertyDefinitions.Add(new PropertyDefinition(name, resolver));
+	}
+
+	/// <summary>
+	/// Adds a read-only reference property definition with the specified name and resolver.
+	/// </summary>
+	/// <param name="name">The name of the property.</param>
+	/// <param name="resolver">The resolver used to compute the property's value at runtime.</param>
+	public void DefineReferenceProperty(StringKey name, IReferenceResolver resolver)
+	{
+		ReferencePropertyDefinitions.Add(new ReferencePropertyDefinition(name, resolver));
 	}
 
 	/// <summary>
@@ -89,6 +144,16 @@ public class GraphVariableDefinitions
 	}
 
 	/// <summary>
+	/// Adds a read-only reference array property definition with the specified name and resolver.
+	/// </summary>
+	/// <param name="name">The name of the array property.</param>
+	/// <param name="resolver">The resolver used to compute the property's array value at runtime.</param>
+	public void DefineReferenceArrayProperty(StringKey name, IReferenceArrayResolver resolver)
+	{
+		ReferenceArrayPropertyDefinitions.Add(new ReferenceArrayPropertyDefinition(name, resolver));
+	}
+
+	/// <summary>
 	/// Validates that the variable or property with the specified name produces a value assignable to the expected
 	/// type. This should be called at graph construction time to catch type mismatches early.
 	/// </summary>
@@ -99,6 +164,14 @@ public class GraphVariableDefinitions
 	public bool ValidatePropertyType(StringKey name, Type expectedType)
 	{
 		foreach (PropertyDefinition definition in PropertyDefinitions)
+		{
+			if (definition.Name == name)
+			{
+				return expectedType.IsAssignableFrom(definition.Resolver.ValueType);
+			}
+		}
+
+		foreach (ReferencePropertyDefinition definition in ReferencePropertyDefinitions)
 		{
 			if (definition.Name == name)
 			{
@@ -120,6 +193,19 @@ public class GraphVariableDefinitions
 			}
 		}
 
+		foreach (ReferenceArrayPropertyDefinition definition in ReferenceArrayPropertyDefinitions)
+		{
+			if (definition.Name == name)
+			{
+				if (expectedType.IsArray && expectedType.GetElementType() is Type elementType)
+				{
+					return elementType.IsAssignableFrom(definition.Resolver.ElementType);
+				}
+
+				return false;
+			}
+		}
+
 		foreach (VariableDefinition definition in VariableDefinitions)
 		{
 			if (definition.Name == name)
@@ -128,7 +214,28 @@ public class GraphVariableDefinitions
 			}
 		}
 
+		foreach (ReferenceVariableDefinition definition in ReferenceVariableDefinitions)
+		{
+			if (definition.Name == name)
+			{
+				return expectedType.IsAssignableFrom(definition.ValueType);
+			}
+		}
+
 		foreach (ArrayVariableDefinition definition in ArrayVariableDefinitions)
+		{
+			if (definition.Name == name)
+			{
+				if (expectedType.IsArray && expectedType.GetElementType() is Type elementType)
+				{
+					return elementType.IsAssignableFrom(definition.ElementType);
+				}
+
+				return false;
+			}
+		}
+
+		foreach (ReferenceArrayVariableDefinition definition in ReferenceArrayVariableDefinitions)
 		{
 			if (definition.Name == name)
 			{
@@ -153,12 +260,26 @@ public class GraphVariableDefinitions
 public readonly record struct ArrayPropertyDefinition(StringKey Name, IArrayPropertyResolver Resolver);
 
 /// <summary>
+/// Represents a named reference array property definition with a resolver.
+/// </summary>
+/// <param name="Name">The name of the array property.</param>
+/// <param name="Resolver">The resolver used to provide the property's array value at runtime.</param>
+public readonly record struct ReferenceArrayPropertyDefinition(StringKey Name, IReferenceArrayResolver Resolver);
+
+/// <summary>
 /// Represents the definition of a graph property, including its name and the resolver used to compute its value at
 /// runtime. This is immutable definition data that belongs to the graph.
 /// </summary>
 /// <param name="Name">The name of the property, used as the lookup key at runtime.</param>
 /// <param name="Resolver">The resolver used to provide the property's value at runtime.</param>
 public readonly record struct PropertyDefinition(StringKey Name, IPropertyResolver Resolver);
+
+/// <summary>
+/// Represents the definition of a graph reference property, including its name and resolver.
+/// </summary>
+/// <param name="Name">The name of the property, used as the lookup key at runtime.</param>
+/// <param name="Resolver">The resolver used to provide the property's value at runtime.</param>
+public readonly record struct ReferencePropertyDefinition(StringKey Name, IReferenceResolver Resolver);
 
 /// <summary>
 /// Represents a named variable definition with an initial value.
@@ -169,9 +290,25 @@ public readonly record struct PropertyDefinition(StringKey Name, IPropertyResolv
 public readonly record struct VariableDefinition(StringKey Name, Variant128 InitialValue, Type ValueType);
 
 /// <summary>
+/// Represents a named reference variable definition with an initial value.
+/// </summary>
+/// <param name="Name">The name of the variable.</param>
+/// <param name="InitialValue">The initial value of the variable.</param>
+/// <param name="ValueType">The type of the variable's value.</param>
+public readonly record struct ReferenceVariableDefinition(StringKey Name, object? InitialValue, Type ValueType);
+
+/// <summary>
 /// Represents a named array variable definition with initial values.
 /// </summary>
 /// <param name="Name">The name of the array variable.</param>
 /// <param name="InitialValues">The initial values for the array elements.</param>
 /// <param name="ElementType">The type of each element in the array.</param>
 public readonly record struct ArrayVariableDefinition(StringKey Name, Variant128[] InitialValues, Type ElementType);
+
+/// <summary>
+/// Represents a named reference array variable definition with initial values.
+/// </summary>
+/// <param name="Name">The name of the array variable.</param>
+/// <param name="InitialValues">The initial values for the array elements.</param>
+/// <param name="ElementType">The type of each element in the array.</param>
+public readonly record struct ReferenceArrayVariableDefinition(StringKey Name, object?[] InitialValues, Type ElementType);

--- a/Forge/Statescript/Properties/AttributeResolver.cs
+++ b/Forge/Statescript/Properties/AttributeResolver.cs
@@ -1,32 +1,35 @@
 // Copyright © Gamesmiths Guild.
 
-using Gamesmiths.Forge.Abilities;
 using Gamesmiths.Forge.Core;
 using Gamesmiths.Forge.Effects.Magnitudes;
 
 namespace Gamesmiths.Forge.Statescript.Properties;
 
 /// <summary>
-/// Resolves a property value by reading a selected value from a specific attribute on the ability owner's entity.
+/// Resolves a property value by reading a selected value from a specific attribute on a resolved entity.
 /// </summary>
 /// <remarks>
-/// <para>This resolver requires the graph to be driven by an ability. It retrieves the owner entity from the
-/// <see cref="AbilityBehaviorContext"/> stored in the graph's <see cref="GraphContext.ActivationContext"/>.</para>
-/// <para>If the graph has no activation context, the activation context is not an <see cref="AbilityBehaviorContext"/>,
-/// or the owner does not have the specified attribute, the resolver returns a default <see cref="Variant128"/>
-/// (zero).</para>
+/// <para>By default, this resolver targets the owner entity through <see cref="OwnerEntityResolver"/>.</para>
+/// <para>If the selected entity is not available or does not have the specified attribute, the resolver returns a
+/// default <see cref="Variant128"/> (zero).</para>
 /// </remarks>
-/// <param name="attributeKey">The fully qualified attribute key (e.g., "CombatAttributeSet.Health").</param>
-/// <param name="attributeCalculationType">Which value to read from the attribute. Defaults to
-/// <see cref="AttributeCalculationType.CurrentValue"/>.</param>
-/// <param name="finalChannel">Only used when <paramref name="attributeCalculationType"/> is
-/// <see cref="AttributeCalculationType.MagnitudeEvaluatedUpToChannel"/>.</param>
+/// <param name="attributeKey">The fully qualified attribute key.</param>
+/// <param name="entityResolver">The entity resolver that selects which entity to inspect.</param>
+/// <param name="attributeCalculationType">Which value to read from the attribute.</param>
+/// <param name="finalChannel">The final channel for channel-limited evaluation.</param>
 public class AttributeResolver(
 	StringKey attributeKey,
+	IEntityResolver entityResolver,
 	AttributeCalculationType attributeCalculationType = AttributeCalculationType.CurrentValue,
 	int finalChannel = 0) : IPropertyResolver
 {
+	private static readonly IEntityResolver _defaultEntityResolver = new OwnerEntityResolver();
+
 	private readonly StringKey _attributeKey = attributeKey;
+
+	private readonly IEntityResolver _entityResolver = entityResolver
+		?? throw new ArgumentNullException(nameof(entityResolver));
+
 	private readonly AttributeCalculationType _attributeCalculationType = attributeCalculationType;
 
 	private readonly int _finalChannel = finalChannel >= 0
@@ -36,22 +39,51 @@ public class AttributeResolver(
 	/// <inheritdoc/>
 	public Type ValueType => typeof(int);
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="AttributeResolver"/> class targeting the owner entity.
+	/// </summary>
+	/// <param name="attributeKey">The fully qualified attribute key.</param>
+	public AttributeResolver(StringKey attributeKey)
+		: this(attributeKey, _defaultEntityResolver)
+	{
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="AttributeResolver"/> class targeting the owner entity.
+	/// </summary>
+	/// <param name="attributeKey">The fully qualified attribute key.</param>
+	/// <param name="attributeCalculationType">Which value to read from the attribute.</param>
+	public AttributeResolver(StringKey attributeKey, AttributeCalculationType attributeCalculationType)
+		: this(attributeKey, _defaultEntityResolver, attributeCalculationType)
+	{
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="AttributeResolver"/> class targeting the owner entity.
+	/// </summary>
+	/// <param name="attributeKey">The fully qualified attribute key.</param>
+	/// <param name="attributeCalculationType">Which value to read from the attribute.</param>
+	/// <param name="finalChannel">The final channel for channel-limited evaluation.</param>
+	public AttributeResolver(
+		StringKey attributeKey,
+		AttributeCalculationType attributeCalculationType,
+		int finalChannel)
+		: this(attributeKey, _defaultEntityResolver, attributeCalculationType, finalChannel)
+	{
+	}
+
 	/// <inheritdoc/>
 	public Variant128 Resolve(GraphContext graphContext)
 	{
-		if (!graphContext.TryGetActivationContext(out AbilityBehaviorContext? abilityContext))
-		{
-			return default;
-		}
-
-		if (!abilityContext.Owner.Attributes.ContainsAttribute(_attributeKey))
+		IForgeEntity? entity = _entityResolver.Resolve(graphContext);
+		if (entity?.Attributes.ContainsAttribute(_attributeKey) != true)
 		{
 			return default;
 		}
 
 		return new Variant128(
 			_attributeCalculationType.ResolveValue(
-				abilityContext.Owner.Attributes[_attributeKey],
+				entity.Attributes[_attributeKey],
 				_finalChannel));
 	}
 }

--- a/Forge/Statescript/Properties/EntityArrayVariableResolver.cs
+++ b/Forge/Statescript/Properties/EntityArrayVariableResolver.cs
@@ -1,0 +1,15 @@
+// Copyright © Gamesmiths Guild.
+
+using Gamesmiths.Forge.Core;
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves an array of <see cref="IForgeEntity"/> references from either graph variables or shared variables.
+/// </summary>
+/// <param name="variableName">The name of the array variable to read.</param>
+/// <param name="scope">Which variable bag to read from.</param>
+public class EntityArrayVariableResolver(StringKey variableName, VariableScope scope = VariableScope.Graph)
+	: ReferenceArrayVariableResolver<IForgeEntity>(variableName, scope)
+{
+}

--- a/Forge/Statescript/Properties/EntityVariableResolver.cs
+++ b/Forge/Statescript/Properties/EntityVariableResolver.cs
@@ -1,0 +1,15 @@
+// Copyright © Gamesmiths Guild.
+
+using Gamesmiths.Forge.Core;
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves an <see cref="IForgeEntity"/> reference from either graph variables or shared variables.
+/// </summary>
+/// <param name="variableName">The name of the variable to read.</param>
+/// <param name="scope">Which variable bag to read from.</param>
+public class EntityVariableResolver(StringKey variableName, VariableScope scope = VariableScope.Graph)
+	: ReferenceVariableResolver<IForgeEntity>(variableName, scope), IEntityResolver
+{
+}

--- a/Forge/Statescript/Properties/IEntityResolver.cs
+++ b/Forge/Statescript/Properties/IEntityResolver.cs
@@ -1,0 +1,12 @@
+// Copyright © Gamesmiths Guild.
+
+using Gamesmiths.Forge.Core;
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves an <see cref="IForgeEntity"/> reference at runtime.
+/// </summary>
+public interface IEntityResolver : IReferenceResolver<IForgeEntity>
+{
+}

--- a/Forge/Statescript/Properties/IReferenceArrayResolver.cs
+++ b/Forge/Statescript/Properties/IReferenceArrayResolver.cs
@@ -1,0 +1,36 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves an array of reference-typed values at runtime.
+/// </summary>
+public interface IReferenceArrayResolver
+{
+	/// <summary>
+	/// Gets the <see cref="Type"/> of each element this resolver produces.
+	/// </summary>
+	Type ElementType { get; }
+
+	/// <summary>
+	/// Resolves the current array value.
+	/// </summary>
+	/// <param name="graphContext">The graph context providing the runtime state.</param>
+	/// <returns>The resolved reference array.</returns>
+	object?[] ResolveArray(GraphContext graphContext);
+}
+
+/// <summary>
+/// Resolves a strongly-typed array of reference values at runtime.
+/// </summary>
+/// <typeparam name="T">The element type produced by the resolver.</typeparam>
+public interface IReferenceArrayResolver<out T> : IReferenceArrayResolver
+	where T : class
+{
+	/// <summary>
+	/// Resolves the current array value.
+	/// </summary>
+	/// <param name="graphContext">The graph context providing the runtime state.</param>
+	/// <returns>The resolved array.</returns>
+	new T?[] ResolveArray(GraphContext graphContext);
+}

--- a/Forge/Statescript/Properties/IReferenceResolver.cs
+++ b/Forge/Statescript/Properties/IReferenceResolver.cs
@@ -1,0 +1,36 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves a reference-typed value at runtime.
+/// </summary>
+public interface IReferenceResolver
+{
+	/// <summary>
+	/// Gets the <see cref="Type"/> of the value this resolver produces.
+	/// </summary>
+	Type ValueType { get; }
+
+	/// <summary>
+	/// Resolves the current value of the property.
+	/// </summary>
+	/// <param name="graphContext">The graph context providing the runtime state.</param>
+	/// <returns>The resolved reference value.</returns>
+	object? Resolve(GraphContext graphContext);
+}
+
+/// <summary>
+/// Resolves a strongly-typed reference value at runtime.
+/// </summary>
+/// <typeparam name="T">The reference type produced by the resolver.</typeparam>
+public interface IReferenceResolver<out T> : IReferenceResolver
+	where T : class
+{
+	/// <summary>
+	/// Resolves the current value of the property.
+	/// </summary>
+	/// <param name="graphContext">The graph context providing the runtime state.</param>
+	/// <returns>The resolved value.</returns>
+	new T? Resolve(GraphContext graphContext);
+}

--- a/Forge/Statescript/Properties/OwnerEntityResolver.cs
+++ b/Forge/Statescript/Properties/OwnerEntityResolver.cs
@@ -1,0 +1,23 @@
+// Copyright © Gamesmiths Guild.
+
+using Gamesmiths.Forge.Abilities;
+using Gamesmiths.Forge.Core;
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the owner entity from the current <see cref="AbilityBehaviorContext"/>.
+/// </summary>
+public class OwnerEntityResolver : ReferenceResolver<IForgeEntity>, IEntityResolver
+{
+	/// <inheritdoc/>
+	public override IForgeEntity? Resolve(GraphContext graphContext)
+	{
+		if (!graphContext.TryGetActivationContext(out AbilityBehaviorContext? abilityContext))
+		{
+			return null;
+		}
+
+		return abilityContext.Owner;
+	}
+}

--- a/Forge/Statescript/Properties/ReferenceArrayResolver.cs
+++ b/Forge/Statescript/Properties/ReferenceArrayResolver.cs
@@ -1,0 +1,22 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Base class for strongly-typed reference array resolvers.
+/// </summary>
+/// <typeparam name="T">The element type produced by the resolver.</typeparam>
+public abstract class ReferenceArrayResolver<T> : IReferenceArrayResolver<T>
+	where T : class
+{
+	/// <inheritdoc/>
+	public abstract T?[] ResolveArray(GraphContext graphContext);
+
+	/// <inheritdoc/>
+	public Type ElementType => typeof(T);
+
+	object?[] IReferenceArrayResolver.ResolveArray(GraphContext graphContext)
+	{
+		return ResolveArray(graphContext);
+	}
+}

--- a/Forge/Statescript/Properties/ReferenceArrayVariableResolver.cs
+++ b/Forge/Statescript/Properties/ReferenceArrayVariableResolver.cs
@@ -1,0 +1,41 @@
+// Copyright © Gamesmiths Guild.
+
+using Gamesmiths.Forge.Core;
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves a reference array from either graph variables or shared variables.
+/// </summary>
+/// <typeparam name="T">The element type to read.</typeparam>
+/// <param name="variableName">The name of the array variable to read.</param>
+/// <param name="scope">Which variable bag to read from.</param>
+public class ReferenceArrayVariableResolver<T>(
+	StringKey variableName,
+	VariableScope scope = VariableScope.Graph) : ReferenceArrayResolver<T>
+	where T : class
+{
+	private readonly StringKey _variableName = variableName;
+	private readonly VariableScope _scope = scope;
+
+	/// <inheritdoc/>
+	public override T?[] ResolveArray(GraphContext graphContext)
+	{
+		return _scope switch
+		{
+			VariableScope.Graph => graphContext.GraphVariables.TryGetReferenceArray(_variableName, out T?[]? values)
+				? values ?? []
+				: [],
+			VariableScope.Shared => graphContext.SharedVariables is not null &&
+				graphContext.SharedVariables.TryGetReferenceArray(_variableName, out T?[]? values)
+					? values ?? []
+					: [],
+#pragma warning disable CA2208 // Instantiate argument exceptions correctly
+			_ => throw new ArgumentOutOfRangeException(
+				nameof(scope),
+				_scope,
+				$"Unsupported {nameof(VariableScope)} value."),
+#pragma warning restore CA2208 // Instantiate argument exceptions correctly
+		};
+	}
+}

--- a/Forge/Statescript/Properties/ReferenceResolver.cs
+++ b/Forge/Statescript/Properties/ReferenceResolver.cs
@@ -1,0 +1,22 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Base class for strongly-typed reference resolvers.
+/// </summary>
+/// <typeparam name="T">The reference type produced by the resolver.</typeparam>
+public abstract class ReferenceResolver<T> : IReferenceResolver<T>
+	where T : class
+{
+	/// <inheritdoc/>
+	public abstract T? Resolve(GraphContext graphContext);
+
+	/// <inheritdoc/>
+	public Type ValueType => typeof(T);
+
+	object? IReferenceResolver.Resolve(GraphContext graphContext)
+	{
+		return Resolve(graphContext);
+	}
+}

--- a/Forge/Statescript/Properties/ReferenceVariableResolver.cs
+++ b/Forge/Statescript/Properties/ReferenceVariableResolver.cs
@@ -1,0 +1,40 @@
+// Copyright © Gamesmiths Guild.
+
+using Gamesmiths.Forge.Core;
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves a reference value from either graph variables or shared variables.
+/// </summary>
+/// <typeparam name="T">The reference type to read.</typeparam>
+/// <param name="variableName">The name of the variable to read.</param>
+/// <param name="scope">Which variable bag to read from.</param>
+public class ReferenceVariableResolver<T>(StringKey variableName, VariableScope scope = VariableScope.Graph)
+	: ReferenceResolver<T>
+	where T : class
+{
+	private readonly StringKey _variableName = variableName;
+	private readonly VariableScope _scope = scope;
+
+	/// <inheritdoc/>
+	public override T? Resolve(GraphContext graphContext)
+	{
+		return _scope switch
+		{
+			VariableScope.Graph => graphContext.GraphVariables.TryGetReference(_variableName, out T? value)
+				? value
+				: null,
+			VariableScope.Shared => graphContext.SharedVariables is not null &&
+				graphContext.SharedVariables.TryGetReference(_variableName, out T? value)
+					? value
+					: null,
+#pragma warning disable CA2208 // Instantiate argument exceptions correctly
+			_ => throw new ArgumentOutOfRangeException(
+				nameof(scope),
+				_scope,
+				$"Unsupported {nameof(VariableScope)} value."),
+#pragma warning restore CA2208 // Instantiate argument exceptions correctly
+		};
+	}
+}

--- a/Forge/Statescript/Properties/SourceEntityResolver.cs
+++ b/Forge/Statescript/Properties/SourceEntityResolver.cs
@@ -1,0 +1,23 @@
+// Copyright © Gamesmiths Guild.
+
+using Gamesmiths.Forge.Abilities;
+using Gamesmiths.Forge.Core;
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the source entity from the current <see cref="AbilityBehaviorContext"/>.
+/// </summary>
+public class SourceEntityResolver : ReferenceResolver<IForgeEntity>, IEntityResolver
+{
+	/// <inheritdoc/>
+	public override IForgeEntity? Resolve(GraphContext graphContext)
+	{
+		if (!graphContext.TryGetActivationContext(out AbilityBehaviorContext? abilityContext))
+		{
+			return null;
+		}
+
+		return abilityContext.Source;
+	}
+}

--- a/Forge/Statescript/Properties/TagQueryResolver.cs
+++ b/Forge/Statescript/Properties/TagQueryResolver.cs
@@ -1,21 +1,22 @@
 // Copyright © Gamesmiths Guild.
 
-using Gamesmiths.Forge.Abilities;
+using Gamesmiths.Forge.Core;
 using Gamesmiths.Forge.Tags;
 
 namespace Gamesmiths.Forge.Statescript.Properties;
 
 /// <summary>
-/// Resolves a property value by evaluating a <see cref="TagQuery"/> against one of the ability owner's tag containers.
+/// Resolves a property value by evaluating a <see cref="TagQuery"/> against one of a resolved entity's tag containers.
 /// </summary>
 /// <remarks>
-/// <para>This resolver requires the graph to be driven by an ability. It retrieves the owner entity from the
-/// <see cref="AbilityBehaviorContext"/> stored in the graph's <see cref="GraphContext.ActivationContext"/>.</para>
-/// <para>If the graph has no activation context or the activation context is not an
-/// <see cref="AbilityBehaviorContext"/>, the resolver always returns <see langword="false"/>.</para>
+/// <para>By default, this resolver targets the owner entity through <see cref="OwnerEntityResolver"/>.</para>
+/// <para>If the selected entity is not available, the resolver returns <see langword="false"/>.</para>
 /// </remarks>
 public class TagQueryResolver : IPropertyResolver
 {
+	private static readonly IEntityResolver _defaultEntityResolver = new OwnerEntityResolver();
+
+	private readonly IEntityResolver _entityResolver;
 	private readonly TagQuery _query;
 	private readonly TagQuerySource _tagQuerySource;
 
@@ -26,15 +27,47 @@ public class TagQueryResolver : IPropertyResolver
 	/// Initializes a new instance of the <see cref="TagQueryResolver"/> class from a prebuilt query.
 	/// </summary>
 	/// <param name="query">The query to evaluate against the selected tag container.</param>
+	public TagQueryResolver(TagQuery query)
+		: this(query, _defaultEntityResolver)
+	{
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="TagQueryResolver"/> class from a prebuilt query.
+	/// </summary>
+	/// <param name="query">The query to evaluate against the selected tag container.</param>
+	/// <param name="tagQuerySource">Which tag container to evaluate against. Defaults to all tags.</param>
+	public TagQueryResolver(TagQuery query, TagQuerySource tagQuerySource)
+		: this(query, _defaultEntityResolver, tagQuerySource)
+	{
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="TagQueryResolver"/> class from a prebuilt query.
+	/// </summary>
+	/// <param name="query">The query to evaluate against the selected tag container.</param>
+	/// <param name="entityResolver">The entity resolver that selects which entity to inspect.</param>
 	/// <param name="tagQuerySource">Which tag container to evaluate against. Defaults to all tags.</param>
 	public TagQueryResolver(
 		TagQuery query,
+		IEntityResolver entityResolver,
 		TagQuerySource tagQuerySource = TagQuerySource.AllTags)
 	{
 		EnsureNotNull(query, nameof(query));
+		EnsureNotNull(entityResolver, nameof(entityResolver));
 
+		_entityResolver = entityResolver;
 		_query = query;
 		_tagQuerySource = tagQuerySource;
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="TagQueryResolver"/> class from a query expression.
+	/// </summary>
+	/// <param name="queryExpression">The expression used to build the tag query.</param>
+	public TagQueryResolver(TagQueryExpression queryExpression)
+		: this(queryExpression, _defaultEntityResolver)
+	{
 	}
 
 	/// <summary>
@@ -44,8 +77,31 @@ public class TagQueryResolver : IPropertyResolver
 	/// <param name="tagQuerySource">Which tag container to evaluate against. Defaults to all tags.</param>
 	public TagQueryResolver(
 		TagQueryExpression queryExpression,
+		TagQuerySource tagQuerySource)
+		: this(queryExpression, _defaultEntityResolver, tagQuerySource)
+	{
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="TagQueryResolver"/> class from a query expression.
+	/// </summary>
+	/// <param name="queryExpression">The expression used to build the tag query.</param>
+	/// <param name="entityResolver">The entity resolver that selects which entity to inspect.</param>
+	/// <param name="tagQuerySource">Which tag container to evaluate against. Defaults to all tags.</param>
+	public TagQueryResolver(
+		TagQueryExpression queryExpression,
+		IEntityResolver entityResolver,
 		TagQuerySource tagQuerySource = TagQuerySource.AllTags)
-		: this(BuildQuery(queryExpression), tagQuerySource)
+		: this(BuildQuery(queryExpression), entityResolver, tagQuerySource)
+	{
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="TagQueryResolver"/> class for the common single-tag match case.
+	/// </summary>
+	/// <param name="tag">The tag to match against the selected tag container.</param>
+	public TagQueryResolver(Tag tag)
+		: this(tag, _defaultEntityResolver)
 	{
 	}
 
@@ -56,20 +112,35 @@ public class TagQueryResolver : IPropertyResolver
 	/// <param name="tagQuerySource">Which tag container to evaluate against. Defaults to all tags.</param>
 	public TagQueryResolver(
 		Tag tag,
+		TagQuerySource tagQuerySource)
+		: this(tag, _defaultEntityResolver, tagQuerySource)
+	{
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="TagQueryResolver"/> class for the common single-tag match case.
+	/// </summary>
+	/// <param name="tag">The tag to match against the selected tag container.</param>
+	/// <param name="entityResolver">The entity resolver that selects which entity to inspect.</param>
+	/// <param name="tagQuerySource">Which tag container to evaluate against. Defaults to all tags.</param>
+	public TagQueryResolver(
+		Tag tag,
+		IEntityResolver entityResolver,
 		TagQuerySource tagQuerySource = TagQuerySource.AllTags)
-		: this(TagQuery.MakeQueryMatchTag(tag), tagQuerySource)
+		: this(TagQuery.MakeQueryMatchTag(tag), entityResolver, tagQuerySource)
 	{
 	}
 
 	/// <inheritdoc/>
 	public Variant128 Resolve(GraphContext graphContext)
 	{
-		if (!graphContext.TryGetActivationContext(out AbilityBehaviorContext? abilityContext))
+		IForgeEntity? entity = _entityResolver.Resolve(graphContext);
+		if (entity is null)
 		{
 			return new Variant128(false);
 		}
 
-		return new Variant128(_query.Matches(GetTagContainer(_tagQuerySource, abilityContext.Owner.Tags)));
+		return new Variant128(_query.Matches(GetTagContainer(_tagQuerySource, entity.Tags)));
 	}
 
 	private static TagQuery BuildQuery(TagQueryExpression queryExpression)
@@ -81,7 +152,7 @@ public class TagQueryResolver : IPropertyResolver
 
 	private static TagContainer GetTagContainer(
 		TagQuerySource tagQuerySource,
-		Core.EntityTags entityTags)
+		EntityTags entityTags)
 	{
 		return tagQuerySource switch
 		{

--- a/Forge/Statescript/Properties/TargetEntityResolver.cs
+++ b/Forge/Statescript/Properties/TargetEntityResolver.cs
@@ -1,0 +1,23 @@
+// Copyright © Gamesmiths Guild.
+
+using Gamesmiths.Forge.Abilities;
+using Gamesmiths.Forge.Core;
+
+namespace Gamesmiths.Forge.Statescript.Properties;
+
+/// <summary>
+/// Resolves the target entity from the current <see cref="AbilityBehaviorContext"/>.
+/// </summary>
+public class TargetEntityResolver : ReferenceResolver<IForgeEntity>, IEntityResolver
+{
+	/// <inheritdoc/>
+	public override IForgeEntity? Resolve(GraphContext graphContext)
+	{
+		if (!graphContext.TryGetActivationContext(out AbilityBehaviorContext? abilityContext))
+		{
+			return null;
+		}
+
+		return abilityContext.Target;
+	}
+}

--- a/Forge/Statescript/Variables.cs
+++ b/Forge/Statescript/Variables.cs
@@ -1,5 +1,6 @@
 // Copyright © Gamesmiths Guild.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using Gamesmiths.Forge.Core;
 
@@ -207,10 +208,10 @@ public class Variables
 				$"Cannot set '{name}': no reference variable with this name exists.");
 		}
 
-		if (!stored.ValueType.IsAssignableFrom(typeof(T)))
+		if (value is not null && !stored.ValueType.IsInstanceOfType(value))
 		{
 			throw new InvalidOperationException(
-				$"Cannot set '{name}' with value type {typeof(T)}: variable expects values assignable to " +
+				$"Cannot set '{name}' with value type {value.GetType()}: variable expects values assignable to " +
 				$"{stored.ValueType}.");
 		}
 
@@ -402,6 +403,7 @@ public class Variables
 	/// <param name="value">The value to set.</param>
 	/// <exception cref="InvalidOperationException">Thrown if no variable with this name exists or if the declared type
 	/// of the variable is not compatible with the value type.</exception>
+	/// <exception cref="ArgumentOutOfRangeException">Thrown if the index is out of range.</exception>
 	public void SetReferenceArrayElement<T>(StringKey name, int index, T? value)
 		where T : class
 	{
@@ -411,10 +413,18 @@ public class Variables
 				$"Cannot set reference array element for '{name}': no array variable with this name exists.");
 		}
 
-		if (!stored.ElementType.IsAssignableFrom(typeof(T)))
+		if ((uint)index >= (uint)stored.Values.Count)
+		{
+			throw new ArgumentOutOfRangeException(
+				nameof(index),
+				index,
+				$"Index {index} is out of range for array '{name}' with length {stored.Values.Count}.");
+		}
+
+		if (value is not null && !stored.ElementType.IsInstanceOfType(value))
 		{
 			throw new InvalidOperationException(
-				$"Cannot set '{name}' with element type {typeof(T)}: array expects values assignable to " +
+				$"Cannot set '{name}' with element type {value.GetType()}: array expects values assignable to " +
 				$"{stored.ElementType}.");
 		}
 

--- a/Forge/Statescript/Variables.cs
+++ b/Forge/Statescript/Variables.cs
@@ -6,7 +6,8 @@ using Gamesmiths.Forge.Core;
 namespace Gamesmiths.Forge.Statescript;
 
 /// <summary>
-/// A mutable bag of named <see cref="Variant128"/> values and <see cref="Variant128"/> arrays. Used for both per-graph
+/// A mutable bag of named value variables and reference variables. This includes <see cref="Variant128"/> values,
+/// <see cref="Variant128"/> arrays, typed reference values, and typed reference arrays. Used for both per-graph
 /// instance variables (<see cref="GraphContext.GraphVariables"/>) and entity-level shared variables
 /// (<see cref="GraphContext.SharedVariables"/>).
 /// </summary>
@@ -21,6 +22,10 @@ public class Variables
 
 	private readonly Dictionary<StringKey, List<Variant128>> _arrays = [];
 
+	private readonly Dictionary<StringKey, ReferenceVariableStorage> _referenceVariables = [];
+
+	private readonly Dictionary<StringKey, ReferenceArrayStorage> _referenceArrays = [];
+
 	/// <summary>
 	/// Initializes the runtime variables from a <see cref="GraphVariableDefinitions"/> instance. For each variable
 	/// definition, a fresh copy is created so that each graph execution has independent mutable state.
@@ -30,6 +35,8 @@ public class Variables
 	{
 		_variables.Clear();
 		_arrays.Clear();
+		_referenceVariables.Clear();
+		_referenceArrays.Clear();
 
 		foreach (VariableDefinition definition in definitions.VariableDefinitions)
 		{
@@ -39,6 +46,18 @@ public class Variables
 		foreach (ArrayVariableDefinition definition in definitions.ArrayVariableDefinitions)
 		{
 			_arrays[definition.Name] = [.. definition.InitialValues];
+		}
+
+		foreach (ReferenceVariableDefinition definition in definitions.ReferenceVariableDefinitions)
+		{
+			_referenceVariables[definition.Name] =
+				new ReferenceVariableStorage(definition.ValueType, definition.InitialValue);
+		}
+
+		foreach (ReferenceArrayVariableDefinition definition in definitions.ReferenceArrayVariableDefinitions)
+		{
+			_referenceArrays[definition.Name] =
+				new ReferenceArrayStorage(definition.ElementType, [.. definition.InitialValues]);
 		}
 	}
 
@@ -145,6 +164,72 @@ public class Variables
 	}
 
 	/// <summary>
+	/// Tries to get the typed reference value of a variable with the given name.
+	/// </summary>
+	/// <typeparam name="T">The reference type to interpret the value as.</typeparam>
+	/// <param name="name">The name of the variable to get.</param>
+	/// <param name="value">The value of the variable if it was found and the declared type is compatible.</param>
+	/// <returns><see langword="true"/> if the variable was found and the requested type is compatible;
+	/// <see langword="false"/> otherwise.</returns>
+	public bool TryGetReference<T>(StringKey name, out T? value)
+		where T : class
+	{
+		value = null;
+
+		if (!_referenceVariables.TryGetValue(name, out ReferenceVariableStorage stored))
+		{
+			return false;
+		}
+
+		if (!typeof(T).IsAssignableFrom(stored.ValueType))
+		{
+			return false;
+		}
+
+		value = (T?)stored.Value;
+		return true;
+	}
+
+	/// <summary>
+	/// Sets the value of a reference variable with the given name.
+	/// </summary>
+	/// <typeparam name="T">The reference type of the value to set.</typeparam>
+	/// <param name="name">The name of the variable to set.</param>
+	/// <param name="value">The value to set.</param>
+	/// <exception cref="InvalidOperationException">Thrown if no variable with this name exists or if the declared type
+	/// of the variable is not compatible with the value type.</exception>
+	public void SetReference<T>(StringKey name, T? value)
+		where T : class
+	{
+		if (!_referenceVariables.TryGetValue(name, out ReferenceVariableStorage stored))
+		{
+			throw new InvalidOperationException(
+				$"Cannot set '{name}': no reference variable with this name exists.");
+		}
+
+		if (!stored.ValueType.IsAssignableFrom(typeof(T)))
+		{
+			throw new InvalidOperationException(
+				$"Cannot set '{name}' with value type {typeof(T)}: variable expects values assignable to " +
+				$"{stored.ValueType}.");
+		}
+
+		_referenceVariables[name] = new ReferenceVariableStorage(stored.ValueType, value);
+	}
+
+	/// <summary>
+	/// Defines a new mutable reference variable directly in this <see cref="Variables"/> bag.
+	/// </summary>
+	/// <typeparam name="T">The reference type of the variable.</typeparam>
+	/// <param name="name">The name of the variable.</param>
+	/// <param name="value">The initial value.</param>
+	public void DefineReferenceVariable<T>(StringKey name, T? value = null)
+		where T : class
+	{
+		_referenceVariables[name] = new ReferenceVariableStorage(typeof(T), value);
+	}
+
+	/// <summary>
 	/// Defines a new mutable array variable directly in this <see cref="Variables"/> bag. If an array variable with
 	/// the given name already exists, its values are replaced.
 	/// </summary>
@@ -158,6 +243,18 @@ public class Variables
 	public void DefineArrayVariable(StringKey name, IEnumerable<Variant128> values)
 	{
 		_arrays[name] = [.. values];
+	}
+
+	/// <summary>
+	/// Defines a new mutable reference array variable directly in this <see cref="Variables"/> bag.
+	/// </summary>
+	/// <typeparam name="T">The reference type of each element.</typeparam>
+	/// <param name="name">The name of the array variable.</param>
+	/// <param name="values">The initial values for the array variable.</param>
+	public void DefineReferenceArrayVariable<T>(StringKey name, IEnumerable<T?> values)
+		where T : class
+	{
+		_referenceArrays[name] = new ReferenceArrayStorage(typeof(T), [.. values.Cast<object?>()]);
 	}
 
 	/// <summary>
@@ -216,6 +313,66 @@ public class Variables
 	}
 
 	/// <summary>
+	/// Gets the element at the specified index from a reference array variable.
+	/// </summary>
+	/// <typeparam name="T">The reference type to interpret the element as.</typeparam>
+	/// <param name="name">The name of the array variable.</param>
+	/// <param name="index">The zero-based index of the element to get.</param>
+	/// <param name="value">The value of the element if found and type-compatible.</param>
+	/// <returns><see langword="true"/> if the array variable was found, the index was valid, and the declared element
+	/// type is compatible; otherwise, <see langword="false"/>.</returns>
+	public bool TryGetReferenceArrayElement<T>(StringKey name, int index, out T? value)
+		where T : class
+	{
+		value = null;
+
+		if (!_referenceArrays.TryGetValue(name, out ReferenceArrayStorage? stored))
+		{
+			return false;
+		}
+
+		if (index < 0 || index >= stored.Values.Count || !typeof(T).IsAssignableFrom(stored.ElementType))
+		{
+			return false;
+		}
+
+		value = (T?)stored.Values[index];
+		return true;
+	}
+
+	/// <summary>
+	/// Tries to get the full typed contents of a reference array variable.
+	/// </summary>
+	/// <typeparam name="T">The reference type to interpret the elements as.</typeparam>
+	/// <param name="name">The name of the array variable.</param>
+	/// <param name="values">The resolved array if found and type-compatible.</param>
+	/// <returns><see langword="true"/> if the array variable was found and the declared element type is compatible;
+	/// <see langword="false"/> otherwise.</returns>
+	public bool TryGetReferenceArray<T>(StringKey name, out T?[]? values)
+		where T : class
+	{
+		values = null;
+
+		if (!_referenceArrays.TryGetValue(name, out ReferenceArrayStorage? stored))
+		{
+			return false;
+		}
+
+		if (!typeof(T).IsAssignableFrom(stored.ElementType))
+		{
+			return false;
+		}
+
+		values = new T?[stored.Values.Count];
+		for (int i = 0; i < stored.Values.Count; i++)
+		{
+			values[i] = (T?)stored.Values[i];
+		}
+
+		return true;
+	}
+
+	/// <summary>
 	/// Sets the element at the specified index in an array variable.
 	/// </summary>
 	/// <typeparam name="T">The type of the value to set. Must be supported by <see cref="Variant128"/>.</typeparam>
@@ -237,6 +394,34 @@ public class Variables
 	}
 
 	/// <summary>
+	/// Sets the element at the specified index in a reference array variable.
+	/// </summary>
+	/// <typeparam name="T">The reference type of the value to set.</typeparam>
+	/// <param name="name">The name of the array variable.</param>
+	/// <param name="index">The zero-based index of the element to set.</param>
+	/// <param name="value">The value to set.</param>
+	/// <exception cref="InvalidOperationException">Thrown if no variable with this name exists or if the declared type
+	/// of the variable is not compatible with the value type.</exception>
+	public void SetReferenceArrayElement<T>(StringKey name, int index, T? value)
+		where T : class
+	{
+		if (!_referenceArrays.TryGetValue(name, out ReferenceArrayStorage? stored))
+		{
+			throw new InvalidOperationException(
+				$"Cannot set reference array element for '{name}': no array variable with this name exists.");
+		}
+
+		if (!stored.ElementType.IsAssignableFrom(typeof(T)))
+		{
+			throw new InvalidOperationException(
+				$"Cannot set '{name}' with element type {typeof(T)}: array expects values assignable to " +
+				$"{stored.ElementType}.");
+		}
+
+		stored.Values[index] = value;
+	}
+
+	/// <summary>
 	/// Gets the length of an array variable.
 	/// </summary>
 	/// <param name="name">The name of the array variable.</param>
@@ -250,6 +435,22 @@ public class Variables
 		}
 
 		return array.Count;
+	}
+
+	/// <summary>
+	/// Gets the length of a reference array variable.
+	/// </summary>
+	/// <param name="name">The name of the array variable.</param>
+	/// <returns>The number of elements in the array, or -1 if the variable does not exist or is not a reference array.
+	/// </returns>
+	public int GetReferenceArrayLength(StringKey name)
+	{
+		if (!_referenceArrays.TryGetValue(name, out ReferenceArrayStorage? stored))
+		{
+			return -1;
+		}
+
+		return stored.Values.Count;
 	}
 
 	/// <summary>
@@ -284,5 +485,14 @@ public class Variables
 			Quaternion quaternion => new Variant128(quaternion),
 			_ => throw new ArgumentException($"{typeof(T)} is not supported by Variant128"),
 		};
+	}
+
+	private readonly record struct ReferenceVariableStorage(Type ValueType, object? Value);
+
+	private sealed class ReferenceArrayStorage(Type elementType, List<object?> values)
+	{
+		public Type ElementType { get; } = elementType;
+
+		public List<object?> Values { get; } = values;
 	}
 }

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -29,6 +29,7 @@ regular node-bindable properties.
 
 | Resolver | Output Type | Description |
 |----------|-------------|-------------|
+| [EntityArrayVariableResolver](entity-array-variable-resolver.md) | `IForgeEntity[]` | Reads an entity reference array from graph or shared scope. |
 | [EntityVariableResolver](entity-variable-resolver.md) | `IForgeEntity?` | Reads an entity reference from graph or shared reference variables. |
 | [OwnerEntityResolver](owner-entity-resolver.md) | `IForgeEntity` | Resolves the owner entity from the current ability activation. |
 | [SourceEntityResolver](source-entity-resolver.md) | `IForgeEntity?` | Resolves the source entity that granted the current ability. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -15,9 +15,24 @@ For an overview of the Statescript system, see the [Statescript overview](../REA
 | [AttributeResolver](attribute-resolver.md) | `int` | Reads a selected value from an entity attribute. |
 | [MagnitudeResolver](magnitude-resolver.md) | `float` | Reads the magnitude from the ability activation context. |
 | [SharedVariableResolver](shared-variable-resolver.md) | *(configured)* | Reads a shared variable from the entity. |
-| [TagQueryResolver](tag-query-resolver.md) | `bool` | Evaluates a tag query against the owner entity's tags. |
+| [TagQueryResolver](tag-query-resolver.md) | `bool` | Evaluates a tag query against a selected entity's tags. |
 | [VariableResolver](variable-resolver.md) | *(configured)* | Reads a graph variable by name. |
 | [VariantResolver](variant-resolver.md) | *(configured)* | Holds a fixed constant value. |
+
+---
+
+## Entity Resolvers
+
+Entity resolvers are typed reference resolvers used by APIs such as `AttributeResolver` and `TagQueryResolver`. They do
+not produce `Variant128` values directly, so they are configured as nested inputs to other resolvers rather than as
+regular node-bindable properties.
+
+| Resolver | Output Type | Description |
+|----------|-------------|-------------|
+| [EntityVariableResolver](entity-variable-resolver.md) | `IForgeEntity?` | Reads an entity reference from graph or shared reference variables. |
+| [OwnerEntityResolver](owner-entity-resolver.md) | `IForgeEntity` | Resolves the owner entity from the current ability activation. |
+| [SourceEntityResolver](source-entity-resolver.md) | `IForgeEntity?` | Resolves the source entity that granted the current ability. |
+| [TargetEntityResolver](target-entity-resolver.md) | `IForgeEntity?` | Resolves the current ability target. |
 
 ---
 

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -29,9 +29,9 @@ regular node-bindable properties.
 
 | Resolver | Output Type | Description |
 |----------|-------------|-------------|
-| [EntityArrayVariableResolver](entity-array-variable-resolver.md) | `IForgeEntity[]` | Reads an entity reference array from graph or shared scope. |
+| [EntityArrayVariableResolver](entity-array-variable-resolver.md) | `IForgeEntity?[]` | Reads an entity reference array from graph or shared scope. |
 | [EntityVariableResolver](entity-variable-resolver.md) | `IForgeEntity?` | Reads an entity reference from graph or shared reference variables. |
-| [OwnerEntityResolver](owner-entity-resolver.md) | `IForgeEntity` | Resolves the owner entity from the current ability activation. |
+| [OwnerEntityResolver](owner-entity-resolver.md) | `IForgeEntity?` | Resolves the owner entity from the current ability activation. |
 | [SourceEntityResolver](source-entity-resolver.md) | `IForgeEntity?` | Resolves the source entity that granted the current ability. |
 | [TargetEntityResolver](target-entity-resolver.md) | `IForgeEntity?` | Resolves the current ability target. |
 

--- a/docs/statescript/resolvers/attribute-resolver.md
+++ b/docs/statescript/resolvers/attribute-resolver.md
@@ -3,7 +3,7 @@
 > **Type:** `Gamesmiths.Forge.Statescript.Properties.AttributeResolver`
 > **Output Type:** `int`
 
-Reads a selected value from a specific entity attribute. Requires the graph to be driven by an ability (accesses the owner entity from `AbilityBehaviorContext` stored in `GraphContext.ActivationContext`).
+Reads a selected value from a specific entity attribute. By default it inspects the owner entity, but it can also target any entity provided by an `IEntityResolver`.
 
 ## Constructors
 
@@ -11,20 +11,24 @@ Reads a selected value from a specific entity attribute. Requires the graph to b
 new AttributeResolver(attributeKey)
 new AttributeResolver(attributeKey, attributeCalculationType)
 new AttributeResolver(attributeKey, attributeCalculationType, finalChannel)
+new AttributeResolver(attributeKey, entityResolver)
+new AttributeResolver(attributeKey, entityResolver, attributeCalculationType)
+new AttributeResolver(attributeKey, entityResolver, attributeCalculationType, finalChannel)
 ```
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | attributeKey | `StringKey` | The fully qualified attribute key (e.g., `"CombatAttributeSet.Health"`). |
+| entityResolver | `IEntityResolver` | Selects which entity to inspect. Defaults to `OwnerEntityResolver`. |
 | attributeCalculationType | `AttributeCalculationType` | Which value to read from the attribute. Defaults to `CurrentValue`. |
 | finalChannel | `int` | Only used with `AttributeCalculationType.MagnitudeEvaluatedUpToChannel`. |
 
 ## Behavior
 
-- Retrieves the owner entity from the `AbilityBehaviorContext` in the graph's activation context.
-- Looks up the attribute by key on the owner entity's `Attributes` collection.
+- Resolves an entity using the configured `IEntityResolver`.
+- Looks up the attribute by key on that entity's `Attributes` collection.
 - Returns the selected attribute value as an `int`.
-- Returns `0` (default `Variant128`) if no activation context is available or the attribute doesn't exist.
+- Returns `0` (default `Variant128`) if the entity cannot be resolved or the attribute doesn't exist.
 
 ### Supported `AttributeCalculationType` values
 
@@ -51,6 +55,24 @@ graph.VariableDefinitions.DefineProperty("healthOverflow",
         AttributeCalculationType.Overflow));
 ```
 
+## Dynamic Entity Example
+
+```csharp
+graph.VariableDefinitions.DefineReferenceVariable<IForgeEntity>("selectedEntity");
+
+graph.VariableDefinitions.DefineProperty("selectedHealth",
+    new AttributeResolver(
+        "CombatAttributeSet.Health",
+        new EntityVariableResolver("selectedEntity")));
+```
+
+```csharp
+graph.VariableDefinitions.DefineProperty("targetHealth",
+    new AttributeResolver(
+        "CombatAttributeSet.Health",
+        new TargetEntityResolver()));
+```
+
 ## Composition
 
 ```csharp
@@ -66,4 +88,7 @@ graph.VariableDefinitions.DefineProperty("healthAbove50",
 
 - [Resolvers Overview](README.md)
 - [ComparisonResolver](comparison-resolver.md)
+- [EntityVariableResolver](entity-variable-resolver.md)
+- [OwnerEntityResolver](owner-entity-resolver.md)
+- [TargetEntityResolver](target-entity-resolver.md)
 - [TagQueryResolver](tag-query-resolver.md)

--- a/docs/statescript/resolvers/entity-array-variable-resolver.md
+++ b/docs/statescript/resolvers/entity-array-variable-resolver.md
@@ -1,0 +1,40 @@
+# EntityArrayVariableResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.EntityArrayVariableResolver`
+> **Output Type:** `IForgeEntity[]`
+
+Reads an entity-reference array from graph or shared reference variables. This is a typed convenience wrapper around
+`ReferenceArrayVariableResolver<IForgeEntity>`.
+
+## Constructors
+
+```csharp
+new EntityArrayVariableResolver(variableName)
+new EntityArrayVariableResolver(variableName, scope)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| variableName | `StringKey` | The name of the reference array variable to read. |
+| scope | `VariableScope` | Which variable bag to read from: `Graph` (default) or `Shared`. |
+
+## Behavior
+
+- Reads an `IForgeEntity[]` reference array from `Variables`.
+- Supports both graph-local and shared variable scopes.
+- Returns an empty array if the variable does not exist or no shared variable bag is available.
+
+## Usage
+
+```csharp
+graph.VariableDefinitions.DefineReferenceArrayVariable<IForgeEntity>("nearbyEntities");
+
+graph.VariableDefinitions.DefineReferenceArrayProperty("candidateTargets",
+    new EntityArrayVariableResolver("nearbyEntities"));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [ArrayVariableResolver](array-resolver.md)
+- [EntityVariableResolver](entity-variable-resolver.md)

--- a/docs/statescript/resolvers/entity-array-variable-resolver.md
+++ b/docs/statescript/resolvers/entity-array-variable-resolver.md
@@ -1,7 +1,7 @@
 # EntityArrayVariableResolver
 
 > **Type:** `Gamesmiths.Forge.Statescript.Properties.EntityArrayVariableResolver`
-> **Output Type:** `IForgeEntity[]`
+> **Output Type:** `IForgeEntity?[]`
 
 Reads an entity-reference array from graph or shared reference variables. This is a typed convenience wrapper around
 `ReferenceArrayVariableResolver<IForgeEntity>`.
@@ -20,7 +20,7 @@ new EntityArrayVariableResolver(variableName, scope)
 
 ## Behavior
 
-- Reads an `IForgeEntity[]` reference array from `Variables`.
+- Reads an `IForgeEntity?[]` reference array from `Variables`.
 - Supports both graph-local and shared variable scopes.
 - Returns an empty array if the variable does not exist or no shared variable bag is available.
 

--- a/docs/statescript/resolvers/entity-variable-resolver.md
+++ b/docs/statescript/resolvers/entity-variable-resolver.md
@@ -1,0 +1,49 @@
+# EntityVariableResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.EntityVariableResolver`
+> **Output Type:** `IForgeEntity?`
+
+Reads an entity reference from graph or shared reference variables so other resolvers can inspect entities selected at
+runtime.
+
+## Constructors
+
+```csharp
+new EntityVariableResolver(variableName)
+new EntityVariableResolver(variableName, scope)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| variableName | `StringKey` | The name of the reference variable to read. |
+| scope | `VariableScope` | Chooses whether to read from graph variables (default) or shared variables. |
+
+## Behavior
+
+- Reads an `IForgeEntity` reference from `Variables`.
+- Supports both graph-local and shared variable scopes.
+- Returns `null` if the variable does not exist or currently has no entity assigned.
+
+## Usage
+
+```csharp
+graph.VariableDefinitions.DefineReferenceVariable<IForgeEntity>("selectedEntity");
+
+graph.VariableDefinitions.DefineProperty("selectedHealth",
+    new AttributeResolver(
+        "CombatAttributeSet.Health",
+        new EntityVariableResolver("selectedEntity")));
+```
+
+```csharp
+graph.VariableDefinitions.DefineProperty("sharedSelectionIsBoss",
+    new TagQueryResolver(
+        Tag.RequestTag(tagsManager, "enemy.boss"),
+        new EntityVariableResolver("selectedEntity", VariableScope.Shared)));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [AttributeResolver](attribute-resolver.md)
+- [TagQueryResolver](tag-query-resolver.md)

--- a/docs/statescript/resolvers/owner-entity-resolver.md
+++ b/docs/statescript/resolvers/owner-entity-resolver.md
@@ -1,7 +1,7 @@
 # OwnerEntityResolver
 
 > **Type:** `Gamesmiths.Forge.Statescript.Properties.OwnerEntityResolver`
-> **Output Type:** `IForgeEntity`
+> **Output Type:** `IForgeEntity?`
 
 Resolves the owner entity from the current `AbilityBehaviorContext`.
 

--- a/docs/statescript/resolvers/owner-entity-resolver.md
+++ b/docs/statescript/resolvers/owner-entity-resolver.md
@@ -1,0 +1,33 @@
+# OwnerEntityResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.OwnerEntityResolver`
+> **Output Type:** `IForgeEntity`
+
+Resolves the owner entity from the current `AbilityBehaviorContext`.
+
+## Constructors
+
+```csharp
+new OwnerEntityResolver()
+```
+
+## Behavior
+
+- Reads `AbilityBehaviorContext.Owner` from `GraphContext.ActivationContext`.
+- Returns the entity that owns the currently executing ability.
+- Returns `null` if no compatible activation context is available.
+
+## Usage
+
+```csharp
+graph.VariableDefinitions.DefineProperty("ownerHealth",
+    new AttributeResolver(
+        "CombatAttributeSet.Health",
+        new OwnerEntityResolver()));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [AttributeResolver](attribute-resolver.md)
+- [TagQueryResolver](tag-query-resolver.md)

--- a/docs/statescript/resolvers/source-entity-resolver.md
+++ b/docs/statescript/resolvers/source-entity-resolver.md
@@ -1,0 +1,33 @@
+# SourceEntityResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.SourceEntityResolver`
+> **Output Type:** `IForgeEntity?`
+
+Resolves the source entity from the current `AbilityBehaviorContext`.
+
+## Constructors
+
+```csharp
+new SourceEntityResolver()
+```
+
+## Behavior
+
+- Reads `AbilityBehaviorContext.Source` from `GraphContext.ActivationContext`.
+- Returns the source entity on the currently executing ability.
+- Returns `null` if no compatible activation context is available or the ability has no source entity.
+
+## Usage
+
+```csharp
+graph.VariableDefinitions.DefineProperty("sourceHasFireAffinity",
+    new TagQueryResolver(
+        Tag.RequestTag(tagsManager, "element.fire"),
+        new SourceEntityResolver()));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [AttributeResolver](attribute-resolver.md)
+- [TagQueryResolver](tag-query-resolver.md)

--- a/docs/statescript/resolvers/tag-query-resolver.md
+++ b/docs/statescript/resolvers/tag-query-resolver.md
@@ -3,17 +3,23 @@
 > **Type:** `Gamesmiths.Forge.Statescript.Properties.TagQueryResolver`
 > **Output Type:** `bool`
 
-Evaluates a `TagQuery` against one of the owner entity's tag containers. This is the primary built-in resolver for tag-based conditions and supports both simple single-tag checks and more expressive nested query logic.
+Evaluates a `TagQuery` against one of a selected entity's tag containers. This is the primary built-in resolver for tag-based conditions and supports both simple single-tag checks and more expressive nested query logic.
 
 ## Constructors
 
 ```csharp
 new TagQueryResolver(query)
 new TagQueryResolver(query, tagQuerySource)
+new TagQueryResolver(query, entityResolver)
+new TagQueryResolver(query, entityResolver, tagQuerySource)
 new TagQueryResolver(queryExpression)
 new TagQueryResolver(queryExpression, tagQuerySource)
+new TagQueryResolver(queryExpression, entityResolver)
+new TagQueryResolver(queryExpression, entityResolver, tagQuerySource)
 new TagQueryResolver(tag)
 new TagQueryResolver(tag, tagQuerySource)
+new TagQueryResolver(tag, entityResolver)
+new TagQueryResolver(tag, entityResolver, tagQuerySource)
 ```
 
 | Parameter | Type | Description |
@@ -21,17 +27,18 @@ new TagQueryResolver(tag, tagQuerySource)
 | query | `TagQuery` | A prebuilt tag query to evaluate. |
 | queryExpression | `TagQueryExpression` | A fluent tag-query expression that will be compiled into a `TagQuery`. |
 | tag | `Tag` | Convenience overload for the common single-tag match case. |
+| entityResolver | `IEntityResolver` | Selects which entity to inspect. Defaults to `OwnerEntityResolver`. |
 | tagQuerySource | `TagQuerySource` | Chooses whether to evaluate against `AllTags` (default), `BaseTags`, or `ModifierTags`. |
 
 ## Behavior
 
-- Retrieves the owner entity from the `AbilityBehaviorContext` in the graph's activation context.
+- Resolves an entity using the configured `IEntityResolver`.
 - Evaluates the configured `TagQuery` against one of:
-  - `abilityContext.Owner.Tags.AllTags` (default)
-  - `abilityContext.Owner.Tags.BaseTags`
-  - `abilityContext.Owner.Tags.ModifierTags`
+  - `entity.Tags.AllTags` (default)
+  - `entity.Tags.BaseTags`
+  - `entity.Tags.ModifierTags`
 - Returns `true` if the query matches, `false` otherwise.
-- Returns `false` if no activation context is available.
+- Returns `false` if the entity cannot be resolved.
 
 ## Usage
 
@@ -46,6 +53,25 @@ graph.VariableDefinitions.DefineProperty("isEnraged",
 graph.VariableDefinitions.DefineProperty("hasTemporaryStun",
     new TagQueryResolver(
         Tag.RequestTag(tagsManager, "status.stunned"),
+        TagQuerySource.ModifierTags));
+```
+
+## Dynamic Entity Example
+
+```csharp
+graph.VariableDefinitions.DefineReferenceVariable<IForgeEntity>("selectedEntity");
+
+graph.VariableDefinitions.DefineProperty("selectedEntityIsBoss",
+    new TagQueryResolver(
+        Tag.RequestTag(tagsManager, "enemy.boss"),
+        new EntityVariableResolver("selectedEntity")));
+```
+
+```csharp
+graph.VariableDefinitions.DefineProperty("targetIsCrowdControlled",
+    new TagQueryResolver(
+        Tag.RequestTag(tagsManager, "status.stunned"),
+        new TargetEntityResolver(),
         TagQuerySource.ModifierTags));
 ```
 
@@ -72,4 +98,7 @@ graph.VariableDefinitions.DefineProperty("canAttackTarget",
 
 - [Resolvers Overview](README.md)
 - [AttributeResolver](attribute-resolver.md)
+- [EntityVariableResolver](entity-variable-resolver.md)
+- [OwnerEntityResolver](owner-entity-resolver.md)
+- [TargetEntityResolver](target-entity-resolver.md)
 - [ExpressionNode](../nodes/condition/expression-node.md)

--- a/docs/statescript/resolvers/target-entity-resolver.md
+++ b/docs/statescript/resolvers/target-entity-resolver.md
@@ -1,0 +1,34 @@
+# TargetEntityResolver
+
+> **Type:** `Gamesmiths.Forge.Statescript.Properties.TargetEntityResolver`
+> **Output Type:** `IForgeEntity?`
+
+Resolves the target entity from the current `AbilityBehaviorContext`.
+
+## Constructors
+
+```csharp
+new TargetEntityResolver()
+```
+
+## Behavior
+
+- Reads `AbilityBehaviorContext.Target` from `GraphContext.ActivationContext`.
+- Returns the target entity supplied when the current ability instance was activated.
+- Returns `null` if no compatible activation context is available or the activation had no target.
+
+## Usage
+
+```csharp
+graph.VariableDefinitions.DefineProperty("targetIsFrozen",
+    new TagQueryResolver(
+        Tag.RequestTag(tagsManager, "status.frozen"),
+        new TargetEntityResolver(),
+        TagQuerySource.ModifierTags));
+```
+
+## See Also
+
+- [Resolvers Overview](README.md)
+- [AttributeResolver](attribute-resolver.md)
+- [TagQueryResolver](tag-query-resolver.md)


### PR DESCRIPTION
## Added
- Support for resolvers of reference types.
- Built-in Entity resolvers:

| Resolver | Output Type | Description |
|----------|-------------|-------------|
| EntityArrayVariableResolver | `IForgeEntity[]` | Reads an entity reference array from graph or shared scope. |
| EntityVariableResolver | `IForgeEntity?` | Reads an entity reference from graph or shared reference variables. |
| OwnerEntityResolver | `IForgeEntity` | Resolves the owner entity from the current ability activation. |
| SourceEntityResolver | `IForgeEntity?` | Resolves the source entity that granted the current ability. |
| TargetEntityResolver | `IForgeEntity?` | Resolves the current ability target. |

## Changed
- TagQueryResolver and AttributeResolvers now make use of the new IEntityResolver.