### PR TITLE
Improved IsValid resolver understand types that track their own validity.

### DIFF
--- a/Forge.Tests/Statescript/Resolvers/IsValidResolverTests.cs
+++ b/Forge.Tests/Statescript/Resolvers/IsValidResolverTests.cs
@@ -96,10 +96,63 @@ public class IsValidResolverTests(TagsAndCuesFixture tagsAndCuesFixture) : IClas
 		resolver.Resolve(context).AsBool().Should().BeTrue();
 	}
 
+	[Fact]
+	[Trait("Resolver", "IsValid")]
+	public void Is_valid_resolver_returns_false_for_invalidated_value()
+	{
+		var context = new GraphContext();
+		context.GraphVariables.DefineObjectVariable<IValidatable>("handle", new FakeHandle(isValid: false));
+
+		var resolver = new IsValidResolver(new ObjectVariableResolver<IValidatable>("handle"));
+
+		resolver.Resolve(context).AsBool().Should().BeFalse();
+	}
+
+	[Fact]
+	[Trait("Resolver", "IsValid")]
+	public void Is_valid_resolver_returns_true_for_still_valid_value()
+	{
+		var context = new GraphContext();
+		context.GraphVariables.DefineObjectVariable<IValidatable>("handle", new FakeHandle(isValid: true));
+
+		var resolver = new IsValidResolver(new ObjectVariableResolver<IValidatable>("handle"));
+
+		resolver.Resolve(context).AsBool().Should().BeTrue();
+	}
+
+	[Fact]
+	[Trait("Resolver", "IsValid")]
+	public void Is_valid_resolver_returns_false_for_empty_tag()
+	{
+		var context = new GraphContext();
+		context.GraphVariables.DefineObjectVariable("tag", Tag.Empty);
+
+		var resolver = new IsValidResolver(new ObjectVariableResolver<Tag>("tag"));
+
+		resolver.Resolve(context).AsBool().Should().BeFalse();
+	}
+
+	[Fact]
+	[Trait("Resolver", "IsValid")]
+	public void Is_valid_resolver_returns_true_for_registered_tag()
+	{
+		var context = new GraphContext();
+		context.GraphVariables.DefineObjectVariable("tag", Tag.RequestTag(_tagsManager, "color.red"));
+
+		var resolver = new IsValidResolver(new ObjectVariableResolver<Tag>("tag"));
+
+		resolver.Resolve(context).AsBool().Should().BeTrue();
+	}
+
 	private static Effect CreateEffect()
 	{
 		return new Effect(
 			new EffectData("Burn", new DurationData(DurationType.Instant)),
 			new EffectOwnership(null, null));
+	}
+
+	private sealed class FakeHandle(bool isValid) : IValidatable
+	{
+		public bool IsValid { get; } = isValid;
 	}
 }

--- a/Forge/Abilities/AbilityHandle.cs
+++ b/Forge/Abilities/AbilityHandle.cs
@@ -8,7 +8,7 @@ namespace Gamesmiths.Forge.Abilities;
 /// <summary>
 /// Represents a handle to a granted ability.
 /// </summary>
-public class AbilityHandle
+public class AbilityHandle : IValidatable
 {
 	/// <summary>
 	/// Gets a value indicating whether the ability associated with this handle is valid and active.

--- a/Forge/Abilities/AbilityInstanceHandle.cs
+++ b/Forge/Abilities/AbilityInstanceHandle.cs
@@ -8,7 +8,7 @@ namespace Gamesmiths.Forge.Abilities;
 /// Slim handle for controlling a single active ability instance (end / cancel).
 /// Additional context (owner, source, level, commits) lives in <see cref="AbilityBehaviorContext"/>.
 /// </summary>
-public sealed class AbilityInstanceHandle
+public sealed class AbilityInstanceHandle : IValidatable
 {
 	/// <summary>
 	/// Gets the target entity of this ability instance.

--- a/Forge/Core/IValidatable.cs
+++ b/Forge/Core/IValidatable.cs
@@ -1,0 +1,23 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Core;
+
+/// <summary>
+/// Implemented by types whose values can stop being usable without becoming <see langword="null"/>.
+/// </summary>
+/// <remarks>
+/// <para>Handles are the usual case: an <see cref="Effects.ActiveEffectHandle"/> whose effect has been removed, or an
+/// <see cref="Abilities.AbilityHandle"/> whose ability has been revoked, is still a perfectly good reference to an
+/// object that no longer refers to anything. A null check says such a value is fine, and everything downstream then
+/// acts on something that is not there.</para>
+/// <para>Implementing this is what lets generic code - notably the Is Valid resolver - ask the question properly
+/// instead of guessing from nullability. Types already exposing an <c>IsValid</c> property satisfy it by declaration
+/// alone.</para>
+/// </remarks>
+public interface IValidatable
+{
+	/// <summary>
+	/// Gets a value indicating whether this value still refers to something usable.
+	/// </summary>
+	bool IsValid { get; }
+}

--- a/Forge/Effects/ActiveEffectHandle.cs
+++ b/Forge/Effects/ActiveEffectHandle.cs
@@ -9,7 +9,7 @@ namespace Gamesmiths.Forge.Effects;
 /// <summary>
 /// Represents a handle to an active effect.
 /// </summary>
-public class ActiveEffectHandle
+public class ActiveEffectHandle : IValidatable
 {
 	/// <summary>
 	/// Gets a value indicating whether the effect is currently inhibited.

--- a/Forge/Statescript/Properties/IsValidResolver.cs
+++ b/Forge/Statescript/Properties/IsValidResolver.cs
@@ -1,16 +1,21 @@
 // Copyright © Gamesmiths Guild.
 
+using Gamesmiths.Forge.Core;
+
 namespace Gamesmiths.Forge.Statescript.Properties;
 
 /// <summary>
-/// Resolves a <see cref="bool"/> indicating whether a nested object-backed resolver produces a valid (non-null) value.
-/// Use this to validate object variables (entities, effects, handles) before acting on them, e.g. "is the stored
-/// target still set?".
+/// Resolves a <see cref="bool"/> indicating whether a nested object-backed resolver produces a usable value. Use this
+/// to validate object variables (entities, effects, handles) before acting on them, e.g. "is the stored target still
+/// set?".
 /// </summary>
 /// <remarks>
-/// A value is considered valid when it is not <see langword="null"/>. Missing variables resolve to
-/// <see langword="null"/> and are therefore reported as invalid. For an "is null" check, wrap this resolver in a
-/// <see cref="NotResolver"/>.
+/// <para>A value is usable when it is not <see langword="null"/> and, for types that implement
+/// <see cref="IValidatable"/>, when it also reports itself valid. That second half matters: a handle whose effect was
+/// removed or whose ability was revoked is not null, so a plain null check would call it valid and everything
+/// downstream would act on something that is no longer there.</para>
+/// <para>Missing variables resolve to <see langword="null"/> and are therefore reported as invalid. For an "is null"
+/// check, wrap this resolver in a <see cref="NotResolver"/>.</para>
 /// </remarks>
 /// <param name="source">The object-backed resolver whose result is checked.</param>
 public class IsValidResolver(IObjectResolver source) : IPropertyResolver
@@ -23,6 +28,22 @@ public class IsValidResolver(IObjectResolver source) : IPropertyResolver
 	/// <inheritdoc/>
 	public Variant128 Resolve(GraphContext graphContext)
 	{
-		return new Variant128(_source.Resolve(graphContext) is not null);
+		return new Variant128(IsValid(_source.Resolve(graphContext)));
+	}
+
+	/// <summary>
+	/// Reports whether a resolved value is valid: present, and valid when it can say. Override to add a check this
+	/// library cannot make on its own, such as whether an engine object has already been destroyed.
+	/// </summary>
+	/// <param name="value">The value to check.</param>
+	/// <returns><see langword="true"/> when the value is valid.</returns>
+	protected virtual bool IsValid(object? value)
+	{
+		return value switch
+		{
+			null => false,
+			IValidatable validatable => validatable.IsValid,
+			_ => true,
+		};
 	}
 }

--- a/Forge/Tags/Tag.cs
+++ b/Forge/Tags/Tag.cs
@@ -8,7 +8,7 @@ namespace Gamesmiths.Forge.Tags;
 /// A tag is an immutable structured label, following a hierarchy like "enemy.undead.zombie" or
 /// "item.consumable.potion.health", that gets registered and managed by the <see cref="TagsManager"/>.
 /// </summary>
-public readonly struct Tag : IEquatable<Tag>
+public readonly struct Tag : IEquatable<Tag>, IValidatable
 {
 	/// <summary>
 	/// Gets a static representation of an empty <see cref="Tag"/>.

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -105,7 +105,7 @@ regular node-bindable properties.
 
 | Resolver | Output Type | Description |
 |----------|-------------|-------------|
-| [IsValidResolver](is-valid-resolver.md) | `bool` | Checks whether an object-backed resolver produces a valid (non-null) value. |
+| [IsValidResolver](is-valid-resolver.md) | `bool` | Checks whether an object-backed resolver produces a usable value: non-`null`, and still valid for types that track their own validity such as handles. |
 | [ObjectEqualsResolver](object-equals-resolver.md) | `bool` | Checks whether two object-backed resolvers produce the same instance (reference identity). |
 
 ---

--- a/docs/statescript/resolvers/is-valid-resolver.md
+++ b/docs/statescript/resolvers/is-valid-resolver.md
@@ -3,7 +3,7 @@
 > **Type:** `Gamesmiths.Forge.Statescript.Properties.IsValidResolver`
 > **Output Type:** `bool`
 
-Checks whether a nested object-backed resolver produces a valid (non-null) value. Use it to validate object variables (entities, effects, handles) in condition nodes before acting on them, e.g. "is the stored target still set?".
+Checks whether a nested object-backed resolver produces a usable value. Use it to validate object variables (entities, effects, handles) in condition nodes before acting on them, e.g. "is the stored target still set?".
 
 ## Constructor
 
@@ -17,15 +17,44 @@ new IsValidResolver(source)
 
 ## Behavior
 
-- Resolves `source` and returns `true` when the result is not `null`.
-- Missing variables resolve to `null` and are therefore reported as invalid.
+- Resolves `source` and returns `true` when the result is usable.
+- A `null` result is never usable. Missing variables resolve to `null` and are therefore reported as invalid.
+- A result implementing [`IValidatable`](#validatable-types) is usable only when its own `IsValid` is `true`. This matters because such values stay non-`null` after they stop referring to anything.
+- Any other non-`null` result is usable.
 - For an "is null" check, wrap this resolver in a [NotResolver](not-resolver.md) or, when driving an `ExpressionNode`, simply connect the `false` port.
+
+## Validatable types
+
+A handle is still a perfectly good reference after the thing it points at is gone, so a null check alone would call it valid and everything downstream would act on nothing. `Gamesmiths.Forge.Core.IValidatable` lets a type answer for itself, and these built-in types implement it:
+
+| Type | Invalid when |
+|------|--------------|
+| `ActiveEffectHandle` | The effect has been removed. |
+| `AbilityHandle` | The ability has been removed from the entity. |
+| `AbilityInstanceHandle` | The ability instance has ended. |
+| `Tag` | The tag is `Tag.Empty`. |
+
+Implement `IValidatable` on your own types to have them checked the same way:
+
+```csharp
+public sealed class TargetLock : IValidatable
+{
+    public IForgeEntity? Target { get; set; }
+
+    public bool IsValid => Target is not null;
+}
+```
+
+> **Note:** engine integrations can extend the check further by overriding the `protected virtual bool IsUsable(object?)` method. The Godot integration does this to also reject objects that have been freed, which are neither `null` nor `IValidatable`.
 
 ## Usage
 
 ```csharp
 new IsValidResolver(new EntityVariableResolver("storedTarget"))              // true when set
 new NotResolver(new IsValidResolver(new EntityVariableResolver("storedTarget")))  // true when null
+
+// An effect that has since been removed reports false, not true
+new IsValidResolver(new ObjectVariableResolver<ActiveEffectHandle>("appliedBuff"))
 ```
 
 ## Composition


### PR DESCRIPTION
## Description

Is Valid only checked for null. Several types here stay non-null after they stop referring to anything - an ActiveEffectHandle whose effect was removed, an AbilityHandle whose ability was revoked, an empty Tag - so the resolver called them valid and everything downstream acted on nothing. That is the opposite of what the resolver is for.